### PR TITLE
Devel grüneisen

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ APEX currently offers calculation methods for the following alloy properties:
 * Interstitial formation energy
 * Generalized stacking fault energy (Gamma line)
 * Phonon spectra
+* Grüneisen parameters and thermal expansion
 * Finite-temperature lattice parameters (FiniteTlatt)
 
 ## What's Inside
@@ -64,7 +65,8 @@ APEX currently offers calculation methods for the following alloy properties:
   - [4.9 Interstitial](#interstitial)
   - [4.10 Gamma Line](#gamma-line-generalised-stacking-fault)
   - [4.11 Phonon Spectra](#phonon-spectra)
-  - [4.12 Finite-Temperature Lattice Parameters](#finite-temperature-lattice-parameters)
+  - [4.12 Grüneisen Parameters and Thermal Expansion](#grüneisen-parameters-and-thermal-expansion)
+  - [4.13 Finite-Temperature Lattice Parameters](#finite-temperature-lattice-parameters)
 - [More Resources](#more-resources)
 
 ## 1.Installation
@@ -630,7 +632,30 @@ APEX integrates parts of [dflow-phonon](https://github.com/Chengqian-Zhang/dflow
 
 The linear-response method accelerates calculations for metallic systems, while the finite-displacement approach works with any calculator that can provide forces (e.g., ABACUS).
 
-### 4.12 Finite-temperature lattice parameters
+### 4.12 Grüneisen parameters and thermal expansion
+
+APEX supports Grüneisen workflows based on phonon calculations at multiple strained volumes. The `sign_only` mode evaluates the heat-capacity-weighted Grüneisen sum and its sign, while the `full` mode additionally fits the bulk modulus from the volume-energy points and reports the volumetric thermal expansion coefficient.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `volume_strains` | Sequence[Float] | Required | Symmetric volume strains around `0.0`, e.g. `[-0.01, 0.0, 0.01]`. |
+| `temperatures` | Sequence[Float] | Required | Temperatures for heat-capacity weighting and thermal expansion output. |
+| `alpha_mode` | String | `"sign_only"` | Output mode: `"sign_only"` or `"full"`. |
+| `bulk_modulus_source` | String | `"eos_fit"` | Bulk modulus source for `full` mode. |
+| `eos_model` | String | `"birch_murnaghan"` | EOS model used for the bulk-modulus fit. |
+| `primitive` | Bool | `false` | Reduce to primitive cell before phonon calculation. |
+| `approach` | String | `"linear"` | Phonon workflow approach; VASP Grüneisen currently uses linear response. |
+| `supercell_size` | Sequence[Int] | `[2, 2, 2]` | Phonon supercell dimensions. |
+| `MESH` | Sequence[Int] | `None` | Reciprocal-space mesh for mode summation. |
+| `PRIMITIVE_AXES` | String | `None` | Custom primitive axes definition. |
+| `BAND` | String | `None` | Band path definition (falls back to SeeK-path when omitted). |
+| `BAND_LABELS` | String | `None` | Labels for band segments. |
+| `BAND_POINTS` | Integer | `51` | Number of sampling points per segment. |
+| `BAND_CONNECTION` | Bool | `true` | Enable band connection estimation. |
+
+For `full` mode, use fixed-volume internal relaxation in `cal_setting` (`relax_pos = true`, `relax_shape = false`, `relax_vol = false`) so the phonon and energy points share the intended volume grid.
+
+### 4.13 Finite-temperature lattice parameters
 APEX now supports the calculation of lattice parameters at finite temperatures in LAMMPS.
 
 | Key | Type | Example | Description |

--- a/apex/config.py
+++ b/apex/config.py
@@ -62,6 +62,7 @@ class Config:
     exclude_upload_files: list = field(default_factory=list)
     lammps_image_name: str = None
     lammps_run_command: str = None
+    phonolammps_run_command: str = None
     vasp_image_name: str = None
     vasp_run_command: str = None
     abacus_image_name: str = None
@@ -251,6 +252,7 @@ class Config:
             "upload_python_packages": self.upload_python_packages,
             "lammps_image_name": self.lammps_image_name,
             "lammps_run_command": self.lammps_run_command,
+            "phonolammps_run_command": self.phonolammps_run_command,
             "vasp_image_name": self.vasp_image_name,
             "vasp_run_command": self.vasp_run_command,
             "abacus_image_name": self.abacus_image_name,

--- a/apex/core/calculator/Lammps.py
+++ b/apex/core/calculator/Lammps.py
@@ -557,6 +557,8 @@ class Lammps(Task):
     def backward_files(self, property_type="relaxation"):
         if property_type == "phonon":
             return ["outlog", "FORCE_CONSTANTS"]
+        elif property_type == "gruneisen":
+            return ["outlog", "FORCE_CONSTANTS", "mesh.yaml", "band.yaml", "phonopy.yaml"]
         elif property_type == "finitetlatt":
             return ["log.lammps", "outlog", "dump.relax", "average_box.txt"]
         else:

--- a/apex/core/calculator/Lammps.py
+++ b/apex/core/calculator/Lammps.py
@@ -558,7 +558,15 @@ class Lammps(Task):
         if property_type == "phonon":
             return ["outlog", "FORCE_CONSTANTS"]
         elif property_type == "gruneisen":
-            return ["outlog", "FORCE_CONSTANTS", "mesh.yaml", "band.yaml", "phonopy.yaml"]
+            return [
+                "log.lammps",
+                "outlog",
+                "dump.relax",
+                "FORCE_CONSTANTS",
+                "mesh.yaml",
+                "band.yaml",
+                "phonopy.yaml",
+            ]
         elif property_type == "finitetlatt":
             return ["log.lammps", "outlog", "dump.relax", "average_box.txt"]
         else:

--- a/apex/core/calculator/VASP.py
+++ b/apex/core/calculator/VASP.py
@@ -79,7 +79,7 @@ class VASP(Task):
         # revise INCAR based on the INCAR provided in the "interaction"
         else:
             approach = None
-            if prop_type == "phonon":
+            if prop_type in {"phonon", "gruneisen"}:
                 approach = task_param.get("approach")
                 logging.info(f"No specification of INCAR for {prop_type} calculation, will auto-generate")
                 if approach == "linear":
@@ -245,8 +245,7 @@ class VASP(Task):
             return ["INCAR", "POTCAR"]
 
     def backward_files(self, property_type="relaxation"):
-        if property_type == "phonon":
+        if property_type in {"phonon", "gruneisen"}:
             return ["OUTCAR", "outlog", "CONTCAR", "OSZICAR", "XDATCAR", "vasprun.xml"]
         else:
             return ["OUTCAR", "outlog", "CONTCAR", "OSZICAR", "XDATCAR"]
-

--- a/apex/core/common_prop.py
+++ b/apex/core/common_prop.py
@@ -14,6 +14,7 @@ from apex.core.property.Vacancy import Vacancy
 from apex.core.property.Phonon import Phonon
 from apex.core.property.Decohesive import Decohesive
 from apex.core.property.FiniteTlatt import FiniteTlatt
+from apex.core.property.Gruneisen import Gruneisen
 from apex.core.lib.utils import create_path
 from apex.core.lib.util import collect_task
 from apex.core.lib.dispatcher import make_submission
@@ -48,6 +49,8 @@ def make_property_instance(parameters, inter_param):
         return Decohesive(parameters, inter_param)
     elif prop_type == "finitetlatt":
         return FiniteTlatt(parameters, inter_param)
+    elif prop_type == "gruneisen":
+        return Gruneisen(parameters, inter_param)
     else:
         raise RuntimeError(f"unknown APEX type {prop_type}")
 

--- a/apex/core/lib/mfp_eosfit.py
+++ b/apex/core/lib/mfp_eosfit.py
@@ -10,7 +10,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 import scipy.integrate as INT
 from scipy.interpolate import *
-from scipy.misc import derivative
 from scipy.optimize import curve_fit, fsolve, leastsq, minimize, root
 from dflow.python import upload_packages
 upload_packages.append(__file__)
@@ -1319,6 +1318,14 @@ def read_velp(fin, fstart, fend):
 
 def init_guess(fin):
     v, e = read_ve(fin)
+    return init_guess_from_data(v, e)
+
+
+def init_guess_from_data(volumes, energies):
+    v = np.asarray(volumes, dtype=float)
+    e = np.asarray(energies, dtype=float)
+    if len(v) < 3:
+        raise ValueError("at least 3 volume-energy points are required for EOS fitting")
     a, b, c = np.polyfit(v, e, 2)  # this comes from pylab
     # initial guesses.
     v0 = np.abs(-b / (2 * a))
@@ -1328,6 +1335,75 @@ def init_guess(fin):
     bpp = 1 * eV2GPa
     x0 = [e0, b0, bp, v0, bpp]
     return x0
+
+
+def fit_birch_murnaghan(volumes, energies, fixed_bp=None):
+    """Fit Birch-Murnaghan E(V) data without writing plot or data files."""
+    vol = np.asarray(volumes, dtype=float)
+    en = np.asarray(energies, dtype=float)
+    if vol.shape != en.shape:
+        raise ValueError("volumes and energies must have the same shape")
+    if len(vol) < 3:
+        raise ValueError("at least 3 volume-energy points are required for EOS fitting")
+    if fixed_bp is None and len(vol) < 4:
+        raise ValueError("free-B0-prime Birch-Murnaghan fitting requires at least 4 points")
+    if np.any(vol <= 0.0):
+        raise ValueError("EOS volumes must be positive")
+
+    order = np.argsort(vol)
+    vol = vol[order]
+    en = en[order]
+    p0 = init_guess_from_data(vol, en)
+
+    if fixed_bp is None:
+        fit_func = "birch"
+        initial = p0[:4]
+
+        def residual(pars, y, x):
+            return y - birch(x, pars)
+
+        fit_variant = "free_bp"
+    else:
+        fit_func = "birch_fixed_bp"
+        initial = [p0[0], p0[1], p0[3]]
+        bp = float(fixed_bp)
+
+        def residual(pars, y, x):
+            full_pars = [pars[0], pars[1], bp, pars[2]]
+            return y - birch(x, full_pars)
+
+        fit_variant = "fixed_bp"
+
+    popt, pcov, infodict, mesg, ier = leastsq(
+        residual,
+        initial,
+        args=(en, vol),
+        full_output=1,
+        maxfev=(len(initial) + 1) * 400,
+    )
+    if ier not in [1, 2, 3, 4]:
+        raise RuntimeError("Optimal parameters not found: " + mesg)
+
+    if fixed_bp is None:
+        e0, b0, bp, v0 = [float(value) for value in popt]
+    else:
+        e0, b0, v0 = [float(value) for value in popt]
+        bp = float(fixed_bp)
+
+    residuals = residual(popt, en, vol)
+    return {
+        "model": "birch_murnaghan",
+        "fit_function": fit_func,
+        "fit_variant": fit_variant,
+        "E0_eV": e0,
+        "B0_eV_per_A3": b0,
+        "K_T_eV_per_A3": b0,
+        "K_T_GPa": b0 * eV2GPa,
+        "B0_prime": bp,
+        "V0_A3": v0,
+        "residual_sum_squares": float(np.sum(residuals**2)),
+        "used_point_count": int(len(vol)),
+    }
 
 
 def repro_ve(func, vol_i, p):

--- a/apex/core/property/Gruneisen.py
+++ b/apex/core/property/Gruneisen.py
@@ -7,7 +7,7 @@ import shutil
 import subprocess
 from typing import Dict, List
 
-from monty.serialization import dumpfn
+from monty.serialization import dumpfn, loadfn
 from pymatgen.core.structure import Structure
 import seekpath
 import yaml
@@ -246,9 +246,6 @@ class Gruneisen(Property):
         return self.parameter
 
     def _compute_lower(self, output_file, all_tasks, all_res):
-        if self.alpha_mode != "sign_only":
-            raise NotImplementedError("full alpha(T) mode is not implemented yet")
-
         output_file = os.path.abspath(output_file)
         work_path = os.path.dirname(output_file)
         ptr_lines = [work_path]
@@ -259,8 +256,22 @@ class Gruneisen(Property):
                 self._ensure_mesh_yaml(task_dir)
 
             task_infos = [self._load_task_info(task_dir) for task_dir in all_tasks]
+            if self.alpha_mode == "full":
+                self._attach_task_energies(task_infos, all_res)
             ref_info, minus_info, plus_info = self._select_reference_triplet(task_infos)
             sign_only = self._compute_sign_only(ref_info, minus_info, plus_info)
+            bulk_modulus = None
+            thermal_expansion = {
+                "alpha_mode": self.alpha_mode,
+                "temperatures": self.temperatures,
+                "sum_gamma_cv": sign_only["sum_gamma_cv"],
+                "sign": sign_only["sign"],
+            }
+            if self.alpha_mode == "full":
+                bulk_modulus = self._fit_bulk_modulus(task_infos)
+                thermal_expansion.update(
+                    self._compute_full_thermal_expansion(ref_info, sign_only, bulk_modulus)
+                )
 
             result = {
                 "volume_points": [
@@ -268,6 +279,13 @@ class Gruneisen(Property):
                         "strain": info["strain"],
                         "volume": info["volume"],
                         "volume_per_atom": info["volume_per_atom"],
+                        "phonon_cell_volume": info["phonon_cell_volume"],
+                        "fit_volume_per_atom": info["fit_volume_per_atom"],
+                        **(
+                            {"energy_per_atom": info["energy_per_atom"]}
+                            if "energy_per_atom" in info
+                            else {}
+                        ),
                     }
                     for info in task_infos
                 ],
@@ -283,26 +301,45 @@ class Gruneisen(Property):
                         "plus_strain": plus_info["strain"],
                     },
                 },
-                "thermal_expansion": {
-                    "alpha_mode": "sign_only",
-                    "temperatures": self.temperatures,
-                    "sum_gamma_cv": sign_only["sum_gamma_cv"],
-                    "sign": sign_only["sign"],
-                },
+                "thermal_expansion": thermal_expansion,
                 "mode_gruneisen": sign_only["mode_gruneisen"],
                 "mode_heat_capacity": sign_only["mode_heat_capacity"],
                 "mode_contributions": sign_only["mode_contributions"],
                 "contribution_summary": sign_only["contribution_summary"],
-                "bulk_modulus": None,
+                "bulk_modulus": bulk_modulus,
             }
 
-            ptr_lines.append("Temperature(K)  SumGammaCv  Sign")
-            for temperature, sum_gamma_cv, sign in zip(
+            if bulk_modulus is not None:
+                ptr_lines.append("VolumePoint  Strain  FitVolumePerAtom(A^3)  EnergyPerAtom(eV)")
+                for idx, info in enumerate(task_infos):
+                    ptr_lines.append(
+                        f"{idx:6d}  {info['strain']: .8f}  "
+                        f"{info['fit_volume_per_atom']: .10e}  {info['energy_per_atom']: .10e}"
+                    )
+                ptr_lines.append(
+                    "# bulk modulus: "
+                    f"K_T={bulk_modulus['K_T_GPa']:.10e} GPa, "
+                    f"K_T={bulk_modulus['K_T_eV_per_A3']:.10e} eV/A^3, "
+                    f"fit_variant={bulk_modulus['fit_variant']}"
+                )
+
+            header = "Temperature(K)  SumGammaCv  Sign"
+            if self.alpha_mode == "full":
+                header = "Temperature(K)  SumGammaCvRaw  SumGammaCvPerCell  Alpha(K^-1)  Sign"
+            ptr_lines.append(header)
+            for temp_idx, (temperature, sum_gamma_cv, sign) in enumerate(zip(
                 self.temperatures,
                 sign_only["sum_gamma_cv"],
                 sign_only["sign"],
-            ):
-                ptr_lines.append(f"{float(temperature):10.4f}  {sum_gamma_cv: .10e}  {sign}")
+            )):
+                if self.alpha_mode == "full":
+                    ptr_lines.append(
+                        f"{float(temperature):10.4f}  {sum_gamma_cv: .10e}  "
+                        f"{thermal_expansion['sum_gamma_cv_per_cell'][temp_idx]: .10e}  "
+                        f"{thermal_expansion['alpha'][temp_idx]: .10e}  {sign}"
+                    )
+                else:
+                    ptr_lines.append(f"{float(temperature):10.4f}  {sum_gamma_cv: .10e}  {sign}")
             ptr_lines.append("# contribution summary")
             for summary in sign_only["contribution_summary"]:
                 ptr_lines.append(
@@ -490,13 +527,122 @@ if __name__ == "__main__":
             [float(band["frequency"]) for band in point["band"]]
             for point in phonon
         ]
+        phonon_cell_path = (
+            os.path.join(task_dir, "POSCAR-unitcell")
+            if self.inter_param["type"] == "vasp"
+            else os.path.join(task_dir, "POSCAR")
+        )
+        phonon_cell_volume = float(volume_data["volume"])
+        phonon_cell_natoms = None
+        if os.path.isfile(phonon_cell_path):
+            phonon_cell_volume = float(vasp_utils.poscar_vol(phonon_cell_path))
+            phonon_cell_natoms = int(vasp_utils.poscar_natoms(phonon_cell_path))
+        elif self.primitive:
+            raise FileNotFoundError(
+                "POSCAR-unitcell is required for primitive gruneisen alpha calculation "
+                f"but was not found at {phonon_cell_path}"
+            )
         return {
             "task_dir": task_dir,
             "strain": float(volume_data["strain"]),
             "volume": float(volume_data["volume"]),
             "volume_per_atom": float(volume_data["volume_per_atom"]),
+            "phonon_cell_volume": phonon_cell_volume,
+            "phonon_cell_natoms": phonon_cell_natoms,
+            "fit_volume_per_atom": float(volume_data["volume_per_atom"]),
             "weights": weights,
             "frequencies": frequencies,
+        }
+
+    def _attach_task_energies(self, task_infos: List[dict], all_res: List[str]) -> None:
+        if len(all_res) != len(task_infos):
+            raise ValueError("full gruneisen requires one result_task.json for each volume task")
+        for info, result_path in zip(task_infos, all_res):
+            if not os.path.isfile(result_path):
+                raise FileNotFoundError(f"result_task.json not found for {info['task_dir']}")
+            task_result = loadfn(result_path)
+            energy = self._last_result_value(task_result, "energies")
+            atom_count = self._result_atom_count(task_result)
+            if atom_count <= 0:
+                raise ValueError(f"invalid atom count in {result_path}")
+            info["energy"] = energy
+            info["atom_count"] = atom_count
+            info["energy_per_atom"] = energy / atom_count
+            if info["phonon_cell_natoms"]:
+                info["fit_volume_per_atom"] = info["phonon_cell_volume"] / info["phonon_cell_natoms"]
+
+    @staticmethod
+    def _last_result_value(task_result, key: str) -> float:
+        try:
+            values = task_result[key]
+        except (KeyError, TypeError):
+            values = task_result["data"][key]
+        if isinstance(values, dict) and "data" in values:
+            values = values["data"]
+        if len(values) == 0:
+            raise ValueError(f"result field {key} is empty")
+        return float(values[-1])
+
+    @staticmethod
+    def _result_atom_count(task_result) -> int:
+        try:
+            atom_numbs = task_result["atom_numbs"]
+        except (KeyError, TypeError):
+            atom_numbs = task_result["data"]["atom_numbs"]
+        if isinstance(atom_numbs, dict) and "data" in atom_numbs:
+            atom_numbs = atom_numbs["data"]
+        return int(sum(atom_numbs))
+
+    def _fit_bulk_modulus(self, task_infos: List[dict]) -> dict:
+        from apex.core.lib.mfp_eosfit import fit_birch_murnaghan
+
+        volumes = [info["fit_volume_per_atom"] for info in task_infos]
+        energies = [info["energy_per_atom"] for info in task_infos]
+        fixed_bp = 4.0 if len(task_infos) == 3 else None
+        fit = fit_birch_murnaghan(volumes, energies, fixed_bp=fixed_bp)
+        if not math.isfinite(fit["K_T_eV_per_A3"]) or fit["K_T_eV_per_A3"] <= 0.0:
+            raise ValueError("full gruneisen requires a positive fitted bulk modulus")
+        if not math.isfinite(fit["K_T_GPa"]) or fit["K_T_GPa"] <= 0.0:
+            raise ValueError("full gruneisen requires a positive fitted bulk modulus")
+        return {
+            "source": self.bulk_modulus_source,
+            "model": self.eos_model,
+            "K_T_GPa": fit["K_T_GPa"],
+            "K_T_eV_per_A3": fit["K_T_eV_per_A3"],
+            "B0_prime": fit["B0_prime"],
+            "V0_per_atom_A3": fit["V0_A3"],
+            "E0_per_atom_eV": fit["E0_eV"],
+            "fit_variant": fit["fit_variant"],
+            "used_point_count": fit["used_point_count"],
+            "residual_sum_squares": fit["residual_sum_squares"],
+        }
+
+    def _compute_full_thermal_expansion(
+        self,
+        ref_info: dict,
+        sign_only: dict,
+        bulk_modulus: dict,
+    ) -> dict:
+        qpoint_weight_sum = sum(ref_info["weights"])
+        if qpoint_weight_sum <= 0:
+            raise ValueError("full gruneisen requires a positive q-point weight sum")
+        reference_volume = ref_info["phonon_cell_volume"]
+        if not math.isfinite(reference_volume) or reference_volume <= 0.0:
+            raise ValueError("full gruneisen requires a positive reference volume")
+        k_t = bulk_modulus["K_T_eV_per_A3"]
+        sum_gamma_cv_per_cell = [
+            value / qpoint_weight_sum for value in sign_only["sum_gamma_cv"]
+        ]
+        alpha = [
+            value / (reference_volume * k_t)
+            for value in sum_gamma_cv_per_cell
+        ]
+        return {
+            "sum_gamma_cv_per_cell": sum_gamma_cv_per_cell,
+            "alpha": alpha,
+            "alpha_unit": "K^-1",
+            "qpoint_weight_sum": qpoint_weight_sum,
+            "reference_volume_for_alpha": reference_volume,
         }
 
     def _select_reference_triplet(self, task_infos: List[dict]) -> tuple[dict, dict, dict]:

--- a/apex/core/property/Gruneisen.py
+++ b/apex/core/property/Gruneisen.py
@@ -3,6 +3,8 @@ import json
 import logging
 import math
 import os
+import shutil
+import subprocess
 from typing import Dict, List
 
 from monty.serialization import dumpfn
@@ -67,6 +69,8 @@ class Gruneisen(Property):
         self.phonolammps_run_command = parameter["phonolammps_run_command"]
         parameter["lammps_run_command"] = parameter.get("lammps_run_command", None)
         self.lammps_run_command = parameter["lammps_run_command"]
+        parameter["approach"] = parameter.get("approach", "linear")
+        self.approach = parameter["approach"]
         parameter["cal_type"] = parameter.get("cal_type", "static")
         self.cal_type = parameter["cal_type"]
         parameter["cal_setting"] = parameter.get("cal_setting", {})
@@ -94,6 +98,8 @@ class Gruneisen(Property):
             raise ValueError("first-version gruneisen only supports bulk_modulus_source='eos_fit'")
         if self.eos_model != "birch_murnaghan":
             raise ValueError("first-version gruneisen only supports eos_model='birch_murnaghan'")
+        if self.approach not in {"linear", "displacement"}:
+            raise ValueError("gruneisen approach must be either 'linear' or 'displacement'")
         if self.cal_setting["relax_pos"] is not True:
             raise ValueError("gruneisen requires cal_setting.relax_pos = true")
         if self.cal_setting["relax_shape"] is not False:
@@ -149,7 +155,15 @@ class Gruneisen(Property):
                 output_task = os.path.join(path_to_work, f"task.{task_id:06d}")
                 os.makedirs(output_task, exist_ok=True)
                 os.chdir(output_task)
-                for file_name in ["POSCAR.orig", "POSCAR", "volume.json", "band.conf"]:
+                for file_name in [
+                    "POSCAR.orig",
+                    "POSCAR",
+                    "POSCAR-unitcell",
+                    "SPOSCAR",
+                    "phonopy_disp.yaml",
+                    "volume.json",
+                    "band.conf",
+                ]:
                     if os.path.exists(file_name):
                         os.remove(file_name)
 
@@ -168,6 +182,8 @@ class Gruneisen(Property):
                 dumpfn(volume_data, "volume.json", indent=4)
                 with open("band.conf", "w") as fp:
                     fp.write(band_payload["band_conf"])
+                if self.inter_param["type"] == "vasp":
+                    self._prepare_vasp_phonon_task()
                 volume_points.append(volume_data)
                 task_list.append(output_task)
 
@@ -199,6 +215,29 @@ class Gruneisen(Property):
                 with open("run_command", "w") as f3:
                     f3.write("bash run_gruneisen_task.sh")
         os.chdir(cwd)
+
+    def _prepare_vasp_phonon_task(self) -> None:
+        if self.approach != "linear":
+            raise NotImplementedError("VASP gruneisen currently supports approach='linear' only")
+
+        if self.primitive:
+            subprocess.check_call("phonopy --symmetry", shell=True)
+            if not os.path.isfile("PPOSCAR"):
+                raise FileNotFoundError("PPOSCAR was not created by phonopy --symmetry")
+            shutil.copyfile("PPOSCAR", "POSCAR-unitcell")
+            shutil.copyfile("PPOSCAR", "POSCAR")
+        else:
+            shutil.copyfile("POSCAR", "POSCAR-unitcell")
+
+        subprocess.check_call(
+            'phonopy -d --dim="%s %s %s" -c POSCAR'
+            % (self.supercell_size[0], self.supercell_size[1], self.supercell_size[2]),
+            shell=True,
+        )
+        if not os.path.isfile("SPOSCAR"):
+            raise FileNotFoundError("SPOSCAR was not created by phonopy")
+        os.remove("POSCAR")
+        os.symlink("SPOSCAR", "POSCAR")
 
     def task_type(self):
         return self.parameter["type"]
@@ -414,7 +453,16 @@ if __name__ == "__main__":
             return
         force_constants = os.path.join(task_dir, "FORCE_CONSTANTS")
         band_conf = os.path.join(task_dir, "band.conf")
-        poscar = os.path.join(task_dir, "POSCAR")
+        if self.inter_param["type"] == "vasp":
+            vasprun = os.path.join(task_dir, "vasprun.xml")
+            if not os.path.isfile(force_constants):
+                if not os.path.isfile(vasprun):
+                    raise FileNotFoundError(f"vasprun.xml not found in {task_dir}")
+                os.chdir(task_dir)
+                subprocess.check_call("phonopy --fc vasprun.xml", shell=True)
+            poscar = os.path.join(task_dir, "POSCAR-unitcell")
+        else:
+            poscar = os.path.join(task_dir, "POSCAR")
         if not os.path.isfile(force_constants):
             raise FileNotFoundError(f"FORCE_CONSTANTS not found in {task_dir}")
         if not os.path.isfile(band_conf):
@@ -422,10 +470,12 @@ if __name__ == "__main__":
         if not os.path.isfile(poscar):
             raise FileNotFoundError(f"POSCAR not found in {task_dir}")
         os.chdir(task_dir)
-        os.system(
-            'phonopy --dim="%s %s %s" -c POSCAR band.conf'
-            % (self.supercell_size[0], self.supercell_size[1], self.supercell_size[2])
+        cell_file = "POSCAR-unitcell" if self.inter_param["type"] == "vasp" else "POSCAR"
+        command = (
+            'phonopy --nomeshsym --dim="%s %s %s" -c %s band.conf'
+            % (self.supercell_size[0], self.supercell_size[1], self.supercell_size[2], cell_file)
         )
+        subprocess.check_call(command, shell=True)
         if not os.path.isfile(mesh_path):
             raise FileNotFoundError(f"mesh.yaml was not created in {task_dir}")
 
@@ -582,8 +632,10 @@ if __name__ == "__main__":
         if frequency_thz <= 0.0 or temperature <= 0.0:
             return 0.0
         x = THZ_TO_K * frequency_thz / temperature
-        exp_x = math.exp(x)
-        return KB_EV_PER_K * (x * x * exp_x / ((exp_x - 1.0) ** 2))
+        exp_neg_x = math.exp(-x)
+        if exp_neg_x == 0.0:
+            return 0.0
+        return KB_EV_PER_K * (x * x * exp_neg_x / ((1.0 - exp_neg_x) ** 2))
 
     @staticmethod
     def _classify_sign(value: float, tol: float = 1e-14) -> str:

--- a/apex/core/property/Gruneisen.py
+++ b/apex/core/property/Gruneisen.py
@@ -1,0 +1,598 @@
+import glob
+import json
+import logging
+import math
+import os
+from typing import Dict, List
+
+from monty.serialization import dumpfn
+from pymatgen.core.structure import Structure
+import seekpath
+import yaml
+
+from apex.core.calculator.Lammps import Lammps
+from apex.core.calculator.lib import lammps_utils
+from apex.core.calculator.lib import vasp_utils
+from apex.core.calculator.calculator import LAMMPS_INTER_TYPE
+from apex.core.property.Property import Property
+from apex.core.property.Phonon import Phonon
+from dflow.python import upload_packages
+
+upload_packages.append(__file__)
+
+
+DEFAULT_CAL_SETTING = {
+    "relax_pos": True,
+    "relax_shape": False,
+    "relax_vol": False,
+}
+
+DEFAULT_SUPERCELL = [2, 2, 2]
+THZ_TO_K = 47.99243073366221
+KB_EV_PER_K = 8.617333262145e-5
+
+
+class Gruneisen(Property):
+    def __init__(self, parameter, inter_param=None):
+        parameter["reproduce"] = parameter.get("reproduce", False)
+        self.reprod = parameter["reproduce"]
+
+        parameter["primitive"] = parameter.get("primitive", False)
+        self.primitive = parameter["primitive"]
+        parameter["supercell_size"] = parameter.get("supercell_size", DEFAULT_SUPERCELL)
+        self.supercell_size = parameter["supercell_size"]
+        parameter["seekpath_from_original"] = parameter.get("seekpath_from_original", False)
+        self.seekpath_from_original = parameter["seekpath_from_original"]
+        parameter["seekpath_param"] = parameter.get("seekpath_param", {})
+        self.seekpath_param = parameter["seekpath_param"]
+        parameter["MESH"] = parameter.get("MESH", None)
+        self.MESH = parameter["MESH"]
+        parameter["PRIMITIVE_AXES"] = parameter.get("PRIMITIVE_AXES", None)
+        self.PRIMITIVE_AXES = parameter["PRIMITIVE_AXES"]
+        parameter["BAND"] = parameter.get("BAND", None)
+        self.BAND = parameter["BAND"]
+        parameter["BAND_LABELS"] = parameter.get("BAND_LABELS", None)
+        self.BAND_LABELS = parameter["BAND_LABELS"]
+        parameter["BAND_POINTS"] = parameter.get("BAND_POINTS", 51)
+        self.BAND_POINTS = parameter["BAND_POINTS"]
+        parameter["BAND_CONNECTION"] = parameter.get("BAND_CONNECTION", True)
+        self.BAND_CONNECTION = parameter["BAND_CONNECTION"]
+        parameter["alpha_mode"] = parameter.get("alpha_mode", "sign_only")
+        self.alpha_mode = parameter["alpha_mode"]
+        parameter["bulk_modulus_source"] = parameter.get("bulk_modulus_source", "eos_fit")
+        self.bulk_modulus_source = parameter["bulk_modulus_source"]
+        parameter["eos_model"] = parameter.get("eos_model", "birch_murnaghan")
+        self.eos_model = parameter["eos_model"]
+        parameter["phonolammps_run_command"] = parameter.get("phonolammps_run_command", None)
+        self.phonolammps_run_command = parameter["phonolammps_run_command"]
+        parameter["lammps_run_command"] = parameter.get("lammps_run_command", None)
+        self.lammps_run_command = parameter["lammps_run_command"]
+        parameter["cal_type"] = parameter.get("cal_type", "static")
+        self.cal_type = parameter["cal_type"]
+        parameter["cal_setting"] = parameter.get("cal_setting", {})
+        for key, value in DEFAULT_CAL_SETTING.items():
+            parameter["cal_setting"].setdefault(key, value)
+        self.cal_setting = parameter["cal_setting"]
+
+        self.volume_strains = parameter["volume_strains"]
+        self.temperatures = parameter["temperatures"]
+        self.parameter = parameter
+        self.inter_param = inter_param if inter_param is not None else {"type": "vasp"}
+
+        self._validate()
+
+    def _validate(self):
+        if len(self.volume_strains) < 3:
+            raise ValueError("volume_strains must contain at least 3 points")
+        if len(self.temperatures) < 1:
+            raise ValueError("temperatures must contain at least 1 point")
+        if not any(math.isclose(float(value), 0.0, abs_tol=1e-10) for value in self.volume_strains):
+            raise ValueError("volume_strains must include 0.0")
+        if self.alpha_mode not in {"sign_only", "full"}:
+            raise ValueError("alpha_mode must be either 'sign_only' or 'full'")
+        if self.bulk_modulus_source != "eos_fit":
+            raise ValueError("first-version gruneisen only supports bulk_modulus_source='eos_fit'")
+        if self.eos_model != "birch_murnaghan":
+            raise ValueError("first-version gruneisen only supports eos_model='birch_murnaghan'")
+        if self.cal_setting["relax_pos"] is not True:
+            raise ValueError("gruneisen requires cal_setting.relax_pos = true")
+        if self.cal_setting["relax_shape"] is not False:
+            raise ValueError("gruneisen requires cal_setting.relax_shape = false")
+        if self.cal_setting["relax_vol"] is not False:
+            raise ValueError("gruneisen requires cal_setting.relax_vol = false")
+
+        volume_strains = [float(value) for value in self.volume_strains]
+        if volume_strains != sorted(volume_strains):
+            raise ValueError("volume_strains must be strictly increasing")
+        if len(set(volume_strains)) != len(volume_strains):
+            raise ValueError("volume_strains must not contain duplicates")
+        if any(float(value) <= 0.0 for value in self.temperatures):
+            raise ValueError("temperatures must be positive")
+        temperatures = [float(value) for value in self.temperatures]
+        if temperatures != sorted(temperatures):
+            raise ValueError("temperatures must be strictly increasing")
+
+        strain_set = {round(value, 10) for value in volume_strains}
+        for value in volume_strains:
+            if not math.isclose(value, 0.0, abs_tol=1e-10):
+                if round(-value, 10) not in strain_set:
+                    raise ValueError("volume_strains must be symmetric around 0.0")
+
+    def make_confs(self, path_to_work, path_to_equi, refine=False):
+        if refine:
+            raise NotImplementedError("gruneisen refine mode is not implemented yet")
+        if self.reprod:
+            raise NotImplementedError("gruneisen reproduce mode is not implemented yet")
+
+        path_to_work = os.path.abspath(path_to_work)
+        if os.path.exists(path_to_work):
+            logging.debug("%s already exists" % path_to_work)
+        else:
+            os.makedirs(path_to_work)
+        path_to_equi = os.path.abspath(path_to_equi)
+
+        equi_contcar = os.path.join(path_to_equi, "CONTCAR")
+        if not os.path.isfile(equi_contcar):
+            raise RuntimeError("please do relaxation first")
+
+        task_list = []
+        volume_path = os.path.join(path_to_work, "volume_points.json")
+        volume_points = []
+        natoms = vasp_utils.poscar_natoms(equi_contcar)
+        base_volume = vasp_utils.poscar_vol(equi_contcar)
+        cwd = os.getcwd()
+        band_payload = self._build_band_payload(equi_contcar)
+
+        try:
+            dumpfn(band_payload["band_path"], os.path.join(path_to_work, "band_path.json"), indent=4)
+            for task_id, strain in enumerate(self.volume_strains):
+                output_task = os.path.join(path_to_work, f"task.{task_id:06d}")
+                os.makedirs(output_task, exist_ok=True)
+                os.chdir(output_task)
+                for file_name in ["POSCAR.orig", "POSCAR", "volume.json", "band.conf"]:
+                    if os.path.exists(file_name):
+                        os.remove(file_name)
+
+                os.symlink(os.path.relpath(equi_contcar), "POSCAR.orig")
+                scale = (1.0 + float(strain)) ** (1.0 / 3.0)
+                vasp_utils.poscar_scale("POSCAR.orig", "POSCAR", scale)
+                scaled_volume = vasp_utils.poscar_vol("POSCAR")
+                volume_data = {
+                    "strain": float(strain),
+                    "scale": scale,
+                    "volume": scaled_volume,
+                    "volume_per_atom": scaled_volume / natoms,
+                    "reference_volume": base_volume,
+                    "reference_volume_per_atom": base_volume / natoms,
+                }
+                dumpfn(volume_data, "volume.json", indent=4)
+                with open("band.conf", "w") as fp:
+                    fp.write(band_payload["band_conf"])
+                volume_points.append(volume_data)
+                task_list.append(output_task)
+
+            os.chdir(path_to_work)
+            dumpfn(volume_points, volume_path, indent=4)
+        finally:
+            os.chdir(cwd)
+        return task_list
+
+    def post_process(self, task_list):
+        cwd = os.getcwd()
+        if self.inter_param["type"] in LAMMPS_INTER_TYPE:
+            helper = Phonon(dict(self.parameter), inter_param=self.inter_param)
+            for task_dir in task_list:
+                os.chdir(task_dir)
+                if os.path.isfile("in.lammps"):
+                    with open("in.lammps", "r") as f1:
+                        contents = f1.readlines()
+                    pair_line_id = None
+                    for idx, line in enumerate(contents):
+                        if "pair_coeff" in line:
+                            pair_line_id = idx
+                            break
+                    if pair_line_id is not None:
+                        contents = contents[: pair_line_id + 1]
+                    with open("in.lammps", "w") as f2:
+                        f2.write(helper._ensure_deepmd_plugin_loaded("".join(contents)))
+                self._write_fixed_volume_relax_inputs(task_dir)
+                with open("run_command", "w") as f3:
+                    f3.write("bash run_gruneisen_task.sh")
+        os.chdir(cwd)
+
+    def task_type(self):
+        return self.parameter["type"]
+
+    def task_param(self):
+        return self.parameter
+
+    def _compute_lower(self, output_file, all_tasks, all_res):
+        if self.alpha_mode != "sign_only":
+            raise NotImplementedError("full alpha(T) mode is not implemented yet")
+
+        output_file = os.path.abspath(output_file)
+        work_path = os.path.dirname(output_file)
+        ptr_lines = [work_path]
+        cwd = os.getcwd()
+
+        try:
+            for task_dir in all_tasks:
+                self._ensure_mesh_yaml(task_dir)
+
+            task_infos = [self._load_task_info(task_dir) for task_dir in all_tasks]
+            ref_info, minus_info, plus_info = self._select_reference_triplet(task_infos)
+            sign_only = self._compute_sign_only(ref_info, minus_info, plus_info)
+
+            result = {
+                "volume_points": [
+                    {
+                        "strain": info["strain"],
+                        "volume": info["volume"],
+                        "volume_per_atom": info["volume_per_atom"],
+                    }
+                    for info in task_infos
+                ],
+                "gruneisen": {
+                    "reference_volume": ref_info["volume"],
+                    "reference_volume_per_atom": ref_info["volume_per_atom"],
+                    "qpoint_count": sign_only["qpoint_count"],
+                    "mode_count": sign_only["mode_count"],
+                    "skipped_mode_count": sign_only["skipped_mode_count"],
+                    "difference_pair": {
+                        "minus_strain": minus_info["strain"],
+                        "reference_strain": ref_info["strain"],
+                        "plus_strain": plus_info["strain"],
+                    },
+                },
+                "thermal_expansion": {
+                    "alpha_mode": "sign_only",
+                    "temperatures": self.temperatures,
+                    "sum_gamma_cv": sign_only["sum_gamma_cv"],
+                    "sign": sign_only["sign"],
+                },
+                "mode_gruneisen": sign_only["mode_gruneisen"],
+                "mode_heat_capacity": sign_only["mode_heat_capacity"],
+                "mode_contributions": sign_only["mode_contributions"],
+                "contribution_summary": sign_only["contribution_summary"],
+                "bulk_modulus": None,
+            }
+
+            ptr_lines.append("Temperature(K)  SumGammaCv  Sign")
+            for temperature, sum_gamma_cv, sign in zip(
+                self.temperatures,
+                sign_only["sum_gamma_cv"],
+                sign_only["sign"],
+            ):
+                ptr_lines.append(f"{float(temperature):10.4f}  {sum_gamma_cv: .10e}  {sign}")
+            ptr_lines.append("# contribution summary")
+            for summary in sign_only["contribution_summary"]:
+                ptr_lines.append(
+                    f"# T={summary['temperature']:.4f}  "
+                    f"positive={summary['positive_sum']:.10e}  "
+                    f"negative={summary['negative_sum']:.10e}  "
+                    f"net={summary['net_sum']:.10e}"
+                )
+            ptr_lines.append(
+                f"# difference pair: {minus_info['strain']} / {ref_info['strain']} / {plus_info['strain']}"
+            )
+            ptr_lines.append(f"# skipped modes: {sign_only['skipped_mode_count']}")
+
+            with open(output_file, "w") as fp:
+                json.dump(result, fp, indent=4)
+
+            return result, "\n".join(ptr_lines) + "\n"
+        finally:
+            os.chdir(cwd)
+
+    def _build_band_payload(self, poscar_path: str) -> dict:
+        structure = Structure.from_file(poscar_path)
+        if self.BAND:
+            band_path = Phonon.phonopy_band_string_2_band_list(self.BAND, self.BAND_LABELS)
+            band_string = self.BAND
+            band_labels = self.BAND_LABELS
+        else:
+            if self.seekpath_from_original:
+                sp = seekpath.get_path_orig_cell(
+                    Phonon.get_seekpath_structure(structure),
+                    **self.seekpath_param,
+                )
+            else:
+                sp = seekpath.get_path(
+                    Phonon.get_seekpath_structure(structure),
+                    **self.seekpath_param,
+                )
+            band_path = Phonon.extract_seekpath_band(sp)
+            band_string, band_labels = Phonon.band_list_2_phonopy_band_string(band_path)
+
+        lines = ["ATOM_NAME =" + "".join(f" {name}" for name in vasp_utils.get_poscar_types(poscar_path))]
+        lines.append(
+            "DIM = %s %s %s" % (
+                self.supercell_size[0],
+                self.supercell_size[1],
+                self.supercell_size[2],
+            )
+        )
+        if self.MESH:
+            lines.append("MESH = %s %s %s" % (self.MESH[0], self.MESH[1], self.MESH[2]))
+        if self.PRIMITIVE_AXES:
+            lines.append(f"PRIMITIVE_AXES = {self.PRIMITIVE_AXES}")
+        lines.append(f"BAND = {band_string}")
+        if band_labels:
+            lines.append(f"BAND_LABELS = {band_labels}")
+        if self.BAND_POINTS:
+            lines.append(f"BAND_POINTS = {self.BAND_POINTS}")
+        if self.BAND_CONNECTION:
+            lines.append(f"BAND_CONNECTION = {self.BAND_CONNECTION}")
+        lines.append("FORCE_CONSTANTS=READ")
+        return {"band_path": band_path, "band_conf": "\n".join(lines) + "\n"}
+
+    def _write_fixed_volume_relax_inputs(self, task_dir: str) -> None:
+        lammps_task = Lammps(self.inter_param, os.path.join(task_dir, "POSCAR"))
+        lammps_task.set_model_param()
+        relax_input = lammps_utils.make_lammps_equi(
+            "conf.lmp",
+            lammps_task.type_map,
+            lammps_task.inter_func,
+            lammps_task.model_param,
+            self.cal_setting.get("etol", 0),
+            self.cal_setting.get("ftol", 1e-10),
+            self.cal_setting.get("maxiter", 5000),
+            self.cal_setting.get("maxeval", 500000),
+            False,
+            prop_type="relaxation",
+        )
+        with open("in.relax.lammps", "w") as fp:
+            fp.write(relax_input)
+        type_map = lammps_utils.element_list(lammps_task.type_map)
+        with open("type_map.json", "w") as fp:
+            json.dump(type_map, fp, indent=4)
+        with open("convert_relax_dump_to_poscar.py", "w") as fp:
+            fp.write(self._relax_dump_converter_script())
+        with open("run_gruneisen_task.sh", "w") as fp:
+            fp.write(self._build_two_stage_run_script())
+
+    def _build_lammps_run_command(self, input_file: str) -> str:
+        command_template = self.lammps_run_command
+        if not command_template:
+            return f"lmp -in {input_file}"
+        if "{input_file}" in command_template:
+            return command_template.format(input_file=input_file)
+        if "in.lammps" in command_template:
+            return command_template.replace("in.lammps", input_file, 1)
+        return f"{command_template} -in {input_file}"
+
+    def _build_two_stage_run_script(self) -> str:
+        relax_cmd = self._build_lammps_run_command("in.relax.lammps")
+        phonon_cmd = Phonon(dict(self.parameter), inter_param=self.inter_param)._build_phonolammps_run_command()
+        return (
+            "#!/usr/bin/env bash\n"
+            "set -euo pipefail\n\n"
+            "cp POSCAR POSCAR.pre_relax\n"
+            f"{relax_cmd}\n"
+            "python3 convert_relax_dump_to_poscar.py dump.relax POSCAR.relaxed type_map.json\n"
+            "cp POSCAR.relaxed POSCAR\n"
+            f"{phonon_cmd}\n"
+        )
+
+    @staticmethod
+    def _relax_dump_converter_script() -> str:
+        return """#!/usr/bin/env python3
+import json
+import sys
+
+import dpdata
+
+
+def main():
+    if len(sys.argv) != 4:
+        raise SystemExit("usage: convert_relax_dump_to_poscar.py DUMP POSCAR_OUT TYPE_MAP_JSON")
+    dump_path, poscar_out, type_map_json = sys.argv[1:]
+    with open(type_map_json, "r") as fp:
+        type_map = json.load(fp)
+    system = dpdata.System(dump_path, fmt="lammps/dump", type_map=type_map)
+    system.to_vasp_poscar(poscar_out, frame_idx=-1)
+    with open(poscar_out, "r") as fp:
+        lines = fp.read().splitlines()
+    labels = []
+    for token in lines[5].split():
+        if "_" in token:
+            labels.append(type_map[int(token.split("_")[1])])
+        else:
+            labels.append(token)
+    lines[5] = " ".join(labels)
+    with open(poscar_out, "w") as fp:
+        fp.write("\\n".join(lines) + "\\n")
+
+
+if __name__ == "__main__":
+    main()
+"""
+
+    def _ensure_mesh_yaml(self, task_dir: str) -> None:
+        mesh_path = os.path.join(task_dir, "mesh.yaml")
+        if os.path.isfile(mesh_path):
+            return
+        force_constants = os.path.join(task_dir, "FORCE_CONSTANTS")
+        band_conf = os.path.join(task_dir, "band.conf")
+        poscar = os.path.join(task_dir, "POSCAR")
+        if not os.path.isfile(force_constants):
+            raise FileNotFoundError(f"FORCE_CONSTANTS not found in {task_dir}")
+        if not os.path.isfile(band_conf):
+            raise FileNotFoundError(f"band.conf not found in {task_dir}")
+        if not os.path.isfile(poscar):
+            raise FileNotFoundError(f"POSCAR not found in {task_dir}")
+        os.chdir(task_dir)
+        os.system(
+            'phonopy --dim="%s %s %s" -c POSCAR band.conf'
+            % (self.supercell_size[0], self.supercell_size[1], self.supercell_size[2])
+        )
+        if not os.path.isfile(mesh_path):
+            raise FileNotFoundError(f"mesh.yaml was not created in {task_dir}")
+
+    def _load_task_info(self, task_dir: str) -> dict:
+        with open(os.path.join(task_dir, "volume.json"), "r") as fp:
+            volume_data = json.load(fp)
+        with open(os.path.join(task_dir, "mesh.yaml"), "r") as fp:
+            mesh_data = yaml.safe_load(fp)
+        phonon = mesh_data["phonon"]
+        weights = [int(point["weight"]) for point in phonon]
+        frequencies = [
+            [float(band["frequency"]) for band in point["band"]]
+            for point in phonon
+        ]
+        return {
+            "task_dir": task_dir,
+            "strain": float(volume_data["strain"]),
+            "volume": float(volume_data["volume"]),
+            "volume_per_atom": float(volume_data["volume_per_atom"]),
+            "weights": weights,
+            "frequencies": frequencies,
+        }
+
+    def _select_reference_triplet(self, task_infos: List[dict]) -> tuple[dict, dict, dict]:
+        ref_candidates = [info for info in task_infos if math.isclose(info["strain"], 0.0, abs_tol=1e-10)]
+        if len(ref_candidates) != 1:
+            raise ValueError("gruneisen sign_only requires exactly one reference task with strain 0.0")
+        ref_info = ref_candidates[0]
+
+        negative_infos = sorted(
+            [info for info in task_infos if info["strain"] < 0.0],
+            key=lambda info: abs(info["strain"]),
+        )
+        positive_infos = sorted(
+            [info for info in task_infos if info["strain"] > 0.0],
+            key=lambda info: abs(info["strain"]),
+        )
+        if not negative_infos or not positive_infos:
+            raise ValueError("gruneisen sign_only requires symmetric negative and positive strain tasks")
+
+        minus_info = negative_infos[0]
+        plus_info = positive_infos[0]
+        if not math.isclose(abs(minus_info["strain"]), abs(plus_info["strain"]), rel_tol=1e-10, abs_tol=1e-10):
+            raise ValueError("nearest positive and negative strains must be symmetric for sign_only mode")
+        return ref_info, minus_info, plus_info
+
+    def _compute_sign_only(self, ref_info: dict, minus_info: dict, plus_info: dict) -> dict:
+        if ref_info["weights"] != minus_info["weights"] or ref_info["weights"] != plus_info["weights"]:
+            raise ValueError("mesh q-point weights must be identical across volume points")
+        if len(ref_info["frequencies"]) != len(minus_info["frequencies"]) or len(ref_info["frequencies"]) != len(plus_info["frequencies"]):
+            raise ValueError("mesh q-point count must be identical across volume points")
+
+        sum_gamma_cv = [0.0 for _ in self.temperatures]
+        positive_sum = [0.0 for _ in self.temperatures]
+        negative_sum = [0.0 for _ in self.temperatures]
+        skipped_mode_count = 0
+
+        log_v_minus = math.log(minus_info["volume"])
+        log_v_plus = math.log(plus_info["volume"])
+        denom = log_v_plus - log_v_minus
+        if math.isclose(denom, 0.0, abs_tol=1e-20):
+            raise ValueError("volume difference for gruneisen central difference is zero")
+
+        qpoint_count = len(ref_info["frequencies"])
+        mode_count = len(ref_info["frequencies"][0]) if qpoint_count else 0
+        mode_gruneisen = []
+        mode_heat_capacity = []
+        mode_contributions = []
+
+        for q_idx in range(qpoint_count):
+            ref_modes = ref_info["frequencies"][q_idx]
+            minus_modes = minus_info["frequencies"][q_idx]
+            plus_modes = plus_info["frequencies"][q_idx]
+            if len(ref_modes) != len(minus_modes) or len(ref_modes) != len(plus_modes):
+                raise ValueError("mesh band count must be identical across volume points")
+            weight = ref_info["weights"][q_idx]
+            gamma_row = []
+            cv_row = {self._temperature_key(temp): [] for temp in self.temperatures}
+            contribution_row = {self._temperature_key(temp): [] for temp in self.temperatures}
+            for mode_idx in range(len(ref_modes)):
+                omega_ref = ref_modes[mode_idx]
+                omega_minus = minus_modes[mode_idx]
+                omega_plus = plus_modes[mode_idx]
+                if omega_ref <= 0.0 or omega_minus <= 0.0 or omega_plus <= 0.0:
+                    skipped_mode_count += 1
+                    gamma_row.append(None)
+                    for temp_idx, temperature in enumerate(self.temperatures):
+                        temp_key = self._temperature_key(temperature)
+                        cv_row[temp_key].append(0.0)
+                        contribution_row[temp_key].append(0.0)
+                    continue
+                gamma = -(math.log(omega_plus) - math.log(omega_minus)) / denom
+                gamma_row.append(gamma)
+                for temp_idx, temperature in enumerate(self.temperatures):
+                    cv = self._mode_heat_capacity(omega_ref, float(temperature))
+                    contribution = weight * gamma * cv
+                    sum_gamma_cv[temp_idx] += contribution
+                    if contribution > 0.0:
+                        positive_sum[temp_idx] += contribution
+                    elif contribution < 0.0:
+                        negative_sum[temp_idx] += contribution
+                    temp_key = self._temperature_key(temperature)
+                    cv_row[temp_key].append(cv)
+                    contribution_row[temp_key].append(contribution)
+
+            mode_gruneisen.append(
+                {
+                    "q_index": q_idx,
+                    "weight": weight,
+                    "omega_ref": ref_modes,
+                    "gamma": gamma_row,
+                }
+            )
+            mode_heat_capacity.append(
+                {
+                    "q_index": q_idx,
+                    "weight": weight,
+                    "cv": cv_row,
+                }
+            )
+            mode_contributions.append(
+                {
+                    "q_index": q_idx,
+                    "weight": weight,
+                    "gamma_cv": contribution_row,
+                }
+            )
+
+        contribution_summary = []
+        for temp_idx, temperature in enumerate(self.temperatures):
+            contribution_summary.append(
+                {
+                    "temperature": float(temperature),
+                    "positive_sum": positive_sum[temp_idx],
+                    "negative_sum": negative_sum[temp_idx],
+                    "net_sum": sum_gamma_cv[temp_idx],
+                }
+            )
+
+        return {
+            "qpoint_count": qpoint_count,
+            "mode_count": mode_count,
+            "skipped_mode_count": skipped_mode_count,
+            "sum_gamma_cv": sum_gamma_cv,
+            "sign": [self._classify_sign(value) for value in sum_gamma_cv],
+            "mode_gruneisen": mode_gruneisen,
+            "mode_heat_capacity": mode_heat_capacity,
+            "mode_contributions": mode_contributions,
+            "contribution_summary": contribution_summary,
+        }
+
+    @staticmethod
+    def _mode_heat_capacity(frequency_thz: float, temperature: float) -> float:
+        if frequency_thz <= 0.0 or temperature <= 0.0:
+            return 0.0
+        x = THZ_TO_K * frequency_thz / temperature
+        exp_x = math.exp(x)
+        return KB_EV_PER_K * (x * x * exp_x / ((exp_x - 1.0) ** 2))
+
+    @staticmethod
+    def _classify_sign(value: float, tol: float = 1e-14) -> str:
+        if value > tol:
+            return "positive"
+        if value < -tol:
+            return "negative"
+        return "zero"
+
+    @staticmethod
+    def _temperature_key(temperature: float) -> str:
+        return str(float(temperature))

--- a/apex/core/property/Phonon.py
+++ b/apex/core/property/Phonon.py
@@ -9,6 +9,7 @@ from typing import List, Dict, Any
 
 import dpdata
 import seekpath
+from pathlib import Path
 from monty.serialization import dumpfn, loadfn
 from pymatgen.core.structure import Structure
 

--- a/apex/core/property/Phonon.py
+++ b/apex/core/property/Phonon.py
@@ -9,7 +9,6 @@ from typing import List, Dict, Any
 
 import dpdata
 import seekpath
-from pathlib import Path
 from monty.serialization import dumpfn, loadfn
 from pymatgen.core.structure import Structure
 
@@ -51,7 +50,7 @@ class Phonon(Property):
                     self.BAND_LABELS = parameter["BAND_LABELS"]
                 else:
                     self.BAND_LABELS = None
-                parameter["BAND_POINTS"] = parameter.get('BAND_POINTS', None)
+                parameter["BAND_POINTS"] = parameter.get('BAND_POINTS', 51)
                 self.BAND_POINTS = parameter["BAND_POINTS"]
                 parameter["BAND_CONNECTION"] = parameter.get('BAND_CONNECTION', True)
                 self.BAND_CONNECTION = parameter["BAND_CONNECTION"]
@@ -72,12 +71,39 @@ class Phonon(Property):
             parameter["init_from_suffix"] = parameter.get("init_from_suffix", "00")
             self.init_from_suffix = parameter["init_from_suffix"]
         self.cal_type = parameter["cal_type"]
+        parameter["phonolammps_run_command"] = parameter.get("phonolammps_run_command", None)
+        self.phonolammps_run_command = parameter["phonolammps_run_command"]
         parameter["cal_setting"] = parameter.get("cal_setting", default_cal_setting)
         for key in default_cal_setting:
             parameter["cal_setting"].setdefault(key, default_cal_setting[key])
         self.cal_setting = parameter["cal_setting"]
         self.parameter = parameter
         self.inter_param = inter_param if inter_param is not None else {"type": "vasp"}
+
+    def _ensure_deepmd_plugin_loaded(self, input_text: str) -> str:
+        if self.inter_param.get("type") != "deepmd":
+            return input_text
+        if "plugin load" in input_text or "pair_style deepmd" not in input_text:
+            return input_text
+        return input_text.replace(
+            "pair_style deepmd",
+            "plugin load libdeepmd_lmp.so\npair_style deepmd",
+            1,
+        )
+
+    def _build_phonolammps_run_command(self) -> str:
+        dim_x, dim_y, dim_z = self.supercell_size
+        command_template = self.phonolammps_run_command
+        if not command_template:
+            return f"phonolammps in.lammps -c POSCAR --dim {dim_x} {dim_y} {dim_z} "
+        return command_template.format(
+            input_file="in.lammps",
+            poscar="POSCAR",
+            dim=f"{dim_x} {dim_y} {dim_z}",
+            dim_x=dim_x,
+            dim_y=dim_y,
+            dim_z=dim_z,
+        )
 
     def make_confs(self, path_to_work, path_to_equi, refine=False):
         path_to_work = os.path.abspath(path_to_work)
@@ -163,9 +189,19 @@ class Phonon(Property):
                     self.primitive = type_param.get("primitive", self.primitive)
                     self.approach = type_param.get("approach", self.approach)
                     self.supercell_size = type_param.get("supercell_size", self.supercell_size)
+                    self.seekpath_from_original = type_param.get(
+                        "seekpath_from_original", self.seekpath_from_original
+                    )
+                    self.seekpath_param = type_param.get(
+                        "seekpath_param", self.seekpath_param
+                    )
                     self.MESH = type_param.get("MESH", self.MESH)
                     self.PRIMITIVE_AXES = type_param.get("PRIMITIVE_AXES", self.PRIMITIVE_AXES)
                     self.BAND = type_param.get("BAND", self.BAND)
+                    if self.BAND:
+                        self.BAND_LABELS = type_param.get("BAND_LABELS", self.BAND_LABELS)
+                    else:
+                        self.BAND_LABELS = None
                     self.BAND_POINTS = type_param.get("BAND_POINTS", self.BAND_POINTS)
                     self.BAND_CONNECTION = type_param.get("BAND_CONNECTION", self.BAND_CONNECTION)
 
@@ -354,12 +390,9 @@ class Phonon(Property):
                     del contents[pair_line_id + 1:]
 
                 with open("in.lammps", 'w') as f2:
-                    for jj in range(len(contents)):
-                        f2.write(contents[jj])
+                    f2.write(self._ensure_deepmd_plugin_loaded("".join(contents)))
                 # dump phonolammps command
-                phonolammps_cmd = "phonolammps in.lammps -c POSCAR --dim %s %s %s " %(
-                    self.supercell_size[0], self.supercell_size[1], self.supercell_size[2]
-                )
+                phonolammps_cmd = self._build_phonolammps_run_command()
                 with open("run_command", 'w') as f3:
                     f3.write(phonolammps_cmd)
         elif inter_type == "vasp":

--- a/apex/op/RunLAMMPS.py
+++ b/apex/op/RunLAMMPS.py
@@ -34,20 +34,22 @@ class RunLAMMPS(OP):
     @OP.exec_sign_check
     def execute(self, op_in: OPIO) -> OPIO:
         cwd = os.getcwd()
-        os.chdir(op_in["input_lammps"])
-        if os.path.exists("run_command"):
-            with open("run_command", 'r') as f:
-                cmd = f.read()
-        else:
-            cmd = op_in["run_command"]
-        exit_code = subprocess.call(cmd, shell=True)
-        if exit_code == 0:
-            logging.info("Call Lammps command successfully!")
-        else:
-            logging.warning(f"Call Lammps command failed with exit code: {exit_code}")
-
-        os.chdir(cwd)
-        op_out = OPIO({
-            "backward_dir": op_in["input_lammps"]
-        })
-        return op_out
+        try:
+            os.chdir(op_in["input_lammps"])
+            if os.path.exists("run_command"):
+                with open("run_command", 'r') as f:
+                    cmd = f.read()
+            else:
+                cmd = op_in["run_command"]
+            exit_code = subprocess.call(cmd, shell=True)
+            if exit_code == 0:
+                logging.info("Call Lammps command successfully!")
+            else:
+                logging.error(f"Call Lammps command failed with exit code: {exit_code}")
+                raise RuntimeError(f"Call Lammps command failed with exit code: {exit_code}")
+            op_out = OPIO({
+                "backward_dir": op_in["input_lammps"]
+            })
+            return op_out
+        finally:
+            os.chdir(cwd)

--- a/apex/submit.py
+++ b/apex/submit.py
@@ -4,6 +4,7 @@ import glob
 import shutil
 import tempfile
 import logging
+import copy
 from typing import List
 from multiprocessing import Pool
 from monty.serialization import loadfn
@@ -281,7 +282,6 @@ def submit(
             flow_type=flow_type,
             exclude_upload_files=wf_config.exclude_upload_files
         )
-
         cwd = os.getcwd()
         os.chdir(tmp_dir)
         flow_id = None
@@ -377,6 +377,7 @@ def submit_workflow(
     run_command = wf_config.basic_config_dict[f"{calculator}_run_command"]
     if not run_command:
         run_command = wf_config.basic_config_dict["run_command"]
+    phonolammps_run_command = wf_config.basic_config_dict["phonolammps_run_command"]
     post_image = make_image
     group_size = wf_config.basic_config_dict["group_size"]
     pool_size = wf_config.basic_config_dict["pool_size"]
@@ -401,6 +402,13 @@ def submit_workflow(
         executor=executor,
         upload_python_packages=upload_python_packages
     )
+
+    if props_param and phonolammps_run_command:
+        props_param = copy.deepcopy(props_param)
+        for prop in props_param.get("properties", []):
+            if prop.get("type") == "phonon":
+                prop["phonolammps_run_command"] = phonolammps_run_command
+
     # submit the workflows
     work_dir_list = []
     for ii in work_dirs:

--- a/apex/submit.py
+++ b/apex/submit.py
@@ -377,6 +377,7 @@ def submit_workflow(
     run_command = wf_config.basic_config_dict[f"{calculator}_run_command"]
     if not run_command:
         run_command = wf_config.basic_config_dict["run_command"]
+    lammps_run_command = wf_config.basic_config_dict["lammps_run_command"]
     phonolammps_run_command = wf_config.basic_config_dict["phonolammps_run_command"]
     post_image = make_image
     group_size = wf_config.basic_config_dict["group_size"]
@@ -403,11 +404,14 @@ def submit_workflow(
         upload_python_packages=upload_python_packages
     )
 
-    if props_param and phonolammps_run_command:
+    if props_param and (phonolammps_run_command or lammps_run_command):
         props_param = copy.deepcopy(props_param)
         for prop in props_param.get("properties", []):
-            if prop.get("type") == "phonon":
-                prop["phonolammps_run_command"] = phonolammps_run_command
+            if prop.get("type") in {"phonon", "gruneisen"}:
+                if phonolammps_run_command:
+                    prop["phonolammps_run_command"] = phonolammps_run_command
+            if prop.get("type") == "gruneisen" and lammps_run_command:
+                prop["lammps_run_command"] = lammps_run_command
 
     # submit the workflows
     work_dir_list = []

--- a/tests/test_gruneisen.py
+++ b/tests/test_gruneisen.py
@@ -1,0 +1,219 @@
+import glob
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+import json
+
+import yaml
+
+from monty.serialization import loadfn
+
+from apex.core.calculator.Lammps import Lammps
+from apex.core.property.Gruneisen import Gruneisen
+
+
+class TestGruneisen(unittest.TestCase):
+    def setUp(self):
+        tests_dir = Path(__file__).resolve().parent
+        self.source_path = tests_dir / "equi" / "vasp" / "CONTCAR"
+        self.tmpdir = tempfile.TemporaryDirectory(prefix="apex-gruneisen-test-")
+        self.work_root = Path(self.tmpdir.name)
+        self.equi_path = self.work_root / "relaxation" / "relax_task"
+        self.target_path = self.work_root / "gruneisen_00"
+        self.equi_path.mkdir(parents=True, exist_ok=True)
+
+        self.prop_param = {
+            "type": "gruneisen",
+            "volume_strains": [-0.02, 0.0, 0.02],
+            "temperatures": [10, 50, 100],
+        }
+        self.gruneisen = Gruneisen(dict(self.prop_param))
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def test_task_type(self):
+        self.assertEqual("gruneisen", self.gruneisen.task_type())
+
+    def test_task_param_defaults(self):
+        task_param = self.gruneisen.task_param()
+        self.assertEqual(task_param["alpha_mode"], "sign_only")
+        self.assertEqual(task_param["bulk_modulus_source"], "eos_fit")
+        self.assertEqual(task_param["eos_model"], "birch_murnaghan")
+        self.assertEqual(task_param["BAND_POINTS"], 51)
+        self.assertEqual(task_param["supercell_size"], [2, 2, 2])
+
+    def test_validation_rejects_invalid_schema(self):
+        with self.assertRaises(ValueError):
+            Gruneisen(
+                {
+                    "type": "gruneisen",
+                    "volume_strains": [-0.02, 0.02],
+                    "temperatures": [10, 50],
+                }
+            )
+        with self.assertRaises(ValueError):
+            Gruneisen(
+                {
+                    "type": "gruneisen",
+                    "volume_strains": [-0.02, 0.01, 0.02],
+                    "temperatures": [10, 50],
+                }
+            )
+        with self.assertRaises(ValueError):
+            Gruneisen(
+                {
+                    "type": "gruneisen",
+                    "volume_strains": [-0.02, 0.0, 0.02],
+                    "temperatures": [0, 50],
+                }
+            )
+
+    def test_make_confs_generates_volume_tasks(self):
+        with self.assertRaises(RuntimeError):
+            self.gruneisen.make_confs(str(self.target_path), str(self.equi_path))
+
+        shutil.copy(self.source_path, self.equi_path / "CONTCAR")
+        task_list = self.gruneisen.make_confs(str(self.target_path), str(self.equi_path))
+        task_dirs = glob.glob(str(self.target_path / "task.*"))
+        self.assertEqual(len(task_dirs), 3)
+        self.assertEqual(len(task_list), 3)
+        self.assertTrue((self.target_path / "volume_points.json").is_file())
+
+        for task_dir, strain in zip(sorted(task_dirs), self.prop_param["volume_strains"]):
+            self.assertTrue((Path(task_dir) / "POSCAR").is_file())
+            self.assertTrue((Path(task_dir) / "POSCAR.orig").exists())
+            self.assertTrue((Path(task_dir) / "volume.json").is_file())
+            volume_data = loadfn(Path(task_dir) / "volume.json")
+            self.assertAlmostEqual(volume_data["strain"], strain)
+            self.assertGreater(volume_data["volume"], 0.0)
+            self.assertGreater(volume_data["volume_per_atom"], 0.0)
+            self.assertTrue((Path(task_dir) / "band.conf").is_file())
+
+        self.assertTrue((self.target_path / "band_path.json").is_file())
+
+    def test_post_process_prepares_phonon_run_inputs_for_lammps(self):
+        deepmd_gruneisen = Gruneisen(
+            {
+                "type": "gruneisen",
+                "volume_strains": [-0.02, 0.0, 0.02],
+                "temperatures": [10, 50, 100],
+                "supercell_size": [2, 2, 2],
+                "lammps_run_command": "/root/.dp1s/bin/lmp -in in.lammps",
+                "phonolammps_run_command": "phonolammps {input_file} -c {poscar} --dim {dim_x} {dim_y} {dim_z}",
+            },
+            inter_param={
+                "type": "deepmd",
+                "model": "frozen_model.pth",
+                "type_map": {"Cu": 0, "O": 1},
+                "deepmd_version": "3.1.1",
+            },
+        )
+        task_dir = self.work_root / "gruneisen_post" / "task.000000"
+        task_dir.mkdir(parents=True, exist_ok=True)
+        (task_dir / "in.lammps").write_text(
+            "clear\npair_style deepmd frozen_model.pth\npair_coeff * * Cu O\nrun 0\n"
+        )
+        (task_dir / "conf.lmp").write_text("LAMMPS data\n")
+        (task_dir / "POSCAR").write_text(self.source_path.read_text())
+
+        deepmd_gruneisen.post_process([str(task_dir)])
+
+        rewritten = (task_dir / "in.lammps").read_text()
+        self.assertIn("plugin load libdeepmd_lmp.so", rewritten)
+        self.assertIn("pair_style deepmd frozen_model.pth", rewritten)
+        self.assertNotIn("run 0", rewritten)
+        self.assertTrue((task_dir / "in.relax.lammps").is_file())
+        self.assertTrue((task_dir / "type_map.json").is_file())
+        self.assertTrue((task_dir / "convert_relax_dump_to_poscar.py").is_file())
+        self.assertEqual((task_dir / "run_command").read_text(), "bash run_gruneisen_task.sh")
+        run_script = (task_dir / "run_gruneisen_task.sh").read_text()
+        self.assertIn("/root/.dp1s/bin/lmp -in in.relax.lammps", run_script)
+        self.assertIn("python3 convert_relax_dump_to_poscar.py dump.relax POSCAR.relaxed type_map.json", run_script)
+        self.assertIn("phonolammps in.lammps -c POSCAR --dim 2 2 2", run_script)
+        self.assertIn("cp POSCAR.relaxed POSCAR", run_script)
+
+    def test_lammps_backward_files_for_gruneisen(self):
+        lammps = Lammps(
+            {
+                "type": "deepmd",
+                "model": "lammps_input/frozen_model.pb",
+                "deepmd_version": "1.1.0",
+                "type_map": {"Al": 0},
+            },
+            str(self.source_path),
+        )
+        self.assertEqual(
+            lammps.backward_files("gruneisen"),
+            ["outlog", "FORCE_CONSTANTS", "mesh.yaml", "band.yaml", "phonopy.yaml"],
+        )
+
+    def test_sign_only_compute_lower_from_synthetic_mesh(self):
+        gruneisen = Gruneisen(
+            {
+                "type": "gruneisen",
+                "volume_strains": [-0.01, 0.0, 0.01],
+                "temperatures": [100, 300],
+                "alpha_mode": "sign_only",
+            }
+        )
+        work_dir = self.work_root / "gruneisen_compute"
+        work_dir.mkdir(parents=True, exist_ok=True)
+        task_dirs = []
+        synthetic = [
+            (-0.01, 99.0, [[4.2, 8.4]]),
+            (0.0, 100.0, [[4.1, 8.2]]),
+            (0.01, 101.0, [[4.0, 8.0]]),
+        ]
+        for task_id, (strain, volume, frequencies) in enumerate(synthetic):
+            task_dir = work_dir / f"task.{task_id:06d}"
+            task_dir.mkdir(parents=True, exist_ok=True)
+            (task_dir / "volume.json").write_text(
+                json.dumps(
+                    {
+                        "strain": strain,
+                        "scale": 1.0,
+                        "volume": volume,
+                        "volume_per_atom": volume / 4.0,
+                        "reference_volume": 100.0,
+                        "reference_volume_per_atom": 25.0,
+                    }
+                )
+            )
+            mesh = {
+                "phonon": [
+                    {
+                        "q-position": [0.0, 0.0, 0.0],
+                        "weight": 1,
+                        "band": [{"frequency": freq} for freq in frequencies[0]],
+                    }
+                ]
+            }
+            (task_dir / "mesh.yaml").write_text(yaml.safe_dump(mesh, sort_keys=False))
+            task_dirs.append(str(task_dir))
+
+        output_file = work_dir / "result.json"
+        result, ptr = gruneisen._compute_lower(str(output_file), task_dirs, [])
+        self.assertEqual(result["thermal_expansion"]["alpha_mode"], "sign_only")
+        self.assertEqual(result["thermal_expansion"]["sign"], ["positive", "positive"])
+        self.assertEqual(result["gruneisen"]["qpoint_count"], 1)
+        self.assertEqual(result["gruneisen"]["mode_count"], 2)
+        self.assertEqual(result["bulk_modulus"], None)
+        self.assertEqual(len(result["mode_gruneisen"]), 1)
+        self.assertEqual(len(result["mode_gruneisen"][0]["gamma"]), 2)
+        self.assertEqual(result["mode_gruneisen"][0]["weight"], 1)
+        self.assertEqual(result["mode_gruneisen"][0]["omega_ref"], [4.1, 8.2])
+        self.assertIn("100.0", result["mode_heat_capacity"][0]["cv"])
+        self.assertIn("300.0", result["mode_heat_capacity"][0]["cv"])
+        self.assertEqual(len(result["mode_heat_capacity"][0]["cv"]["100.0"]), 2)
+        self.assertEqual(len(result["mode_contributions"][0]["gamma_cv"]["300.0"]), 2)
+        self.assertEqual(len(result["contribution_summary"]), 2)
+        self.assertGreater(result["contribution_summary"][0]["positive_sum"], 0.0)
+        self.assertEqual(result["contribution_summary"][0]["negative_sum"], 0.0)
+        self.assertAlmostEqual(
+            result["contribution_summary"][0]["net_sum"],
+            result["thermal_expansion"]["sum_gamma_cv"][0],
+        )
+        self.assertTrue("Temperature(K)  SumGammaCv  Sign" in ptr)
+        self.assertTrue("# contribution summary" in ptr)

--- a/tests/test_gruneisen.py
+++ b/tests/test_gruneisen.py
@@ -12,6 +12,7 @@ import yaml
 from monty.serialization import loadfn
 
 from apex.core.calculator.Lammps import Lammps
+from apex.core.lib.mfp_eosfit import fit_birch_murnaghan
 from apex.core.property.Gruneisen import Gruneisen
 
 
@@ -78,7 +79,14 @@ class TestGruneisen(unittest.TestCase):
             self.gruneisen.make_confs(str(self.target_path), str(self.equi_path))
 
         shutil.copy(self.source_path, self.equi_path / "CONTCAR")
-        task_list = self.gruneisen.make_confs(str(self.target_path), str(self.equi_path))
+        def fake_check_call(command, shell):
+            self.assertTrue(shell)
+            self.assertIn("phonopy -d", command)
+            Path("SPOSCAR").write_text(Path("POSCAR").read_text())
+            Path("phonopy_disp.yaml").write_text("displacements: []\n")
+
+        with patch("apex.core.property.Gruneisen.subprocess.check_call", side_effect=fake_check_call):
+            task_list = self.gruneisen.make_confs(str(self.target_path), str(self.equi_path))
         task_dirs = glob.glob(str(self.target_path / "task.*"))
         self.assertEqual(len(task_dirs), 3)
         self.assertEqual(len(task_list), 3)
@@ -219,7 +227,15 @@ class TestGruneisen(unittest.TestCase):
         )
         self.assertEqual(
             lammps.backward_files("gruneisen"),
-            ["outlog", "FORCE_CONSTANTS", "mesh.yaml", "band.yaml", "phonopy.yaml"],
+            [
+                "log.lammps",
+                "outlog",
+                "dump.relax",
+                "FORCE_CONSTANTS",
+                "mesh.yaml",
+                "band.yaml",
+                "phonopy.yaml",
+            ],
         )
 
     def test_sign_only_compute_lower_from_synthetic_mesh(self):
@@ -291,6 +307,167 @@ class TestGruneisen(unittest.TestCase):
         self.assertTrue("Temperature(K)  SumGammaCv  Sign" in ptr)
         self.assertTrue("# contribution summary" in ptr)
 
+    def test_full_compute_lower_fits_bulk_modulus_and_alpha(self):
+        gruneisen = Gruneisen(
+            {
+                "type": "gruneisen",
+                "volume_strains": [-0.01, 0.0, 0.01],
+                "temperatures": [100, 300],
+                "alpha_mode": "full",
+            }
+        )
+        work_dir = self.work_root / "gruneisen_full"
+        task_dirs, result_paths = self._write_synthetic_gruneisen_tasks(
+            work_dir,
+            [
+                (-0.01, 99.0, [[4.2, 8.4]], -4.0 + 0.01 * (24.75 - 25.0) ** 2),
+                (0.0, 100.0, [[4.1, 8.2]], -4.0),
+                (0.01, 101.0, [[4.0, 8.0]], -4.0 + 0.01 * (25.25 - 25.0) ** 2),
+            ],
+            weight=2,
+        )
+
+        output_file = work_dir / "result.json"
+        result, ptr = gruneisen._compute_lower(str(output_file), task_dirs, result_paths)
+
+        self.assertEqual(result["thermal_expansion"]["alpha_mode"], "full")
+        self.assertGreater(result["bulk_modulus"]["K_T_GPa"], 0.0)
+        self.assertEqual(result["bulk_modulus"]["fit_variant"], "fixed_bp")
+        self.assertEqual(result["thermal_expansion"]["qpoint_weight_sum"], 2)
+        self.assertEqual(len(result["thermal_expansion"]["alpha"]), 2)
+        raw = result["thermal_expansion"]["sum_gamma_cv"][0]
+        per_cell = result["thermal_expansion"]["sum_gamma_cv_per_cell"][0]
+        self.assertAlmostEqual(per_cell, raw / 2.0)
+        expected_alpha = per_cell / (
+            result["thermal_expansion"]["reference_volume_for_alpha"]
+            * result["bulk_modulus"]["K_T_eV_per_A3"]
+        )
+        self.assertAlmostEqual(result["thermal_expansion"]["alpha"][0], expected_alpha)
+        self.assertIn("bulk modulus", ptr)
+        self.assertIn("Alpha(K^-1)", ptr)
+
+    def test_full_compute_lower_rejects_non_positive_bulk_modulus(self):
+        gruneisen = Gruneisen(
+            {
+                "type": "gruneisen",
+                "volume_strains": [-0.01, 0.0, 0.01],
+                "temperatures": [300],
+                "alpha_mode": "full",
+            }
+        )
+        work_dir = self.work_root / "gruneisen_bad_bulk"
+        task_dirs, result_paths = self._write_synthetic_gruneisen_tasks(
+            work_dir,
+            [
+                (-0.01, 99.0, [[4.2, 8.4]], -4.0 - 0.01 * (24.75 - 25.0) ** 2),
+                (0.0, 100.0, [[4.1, 8.2]], -4.0),
+                (0.01, 101.0, [[4.0, 8.0]], -4.0 - 0.01 * (25.25 - 25.0) ** 2),
+            ],
+        )
+
+        with self.assertRaisesRegex(ValueError, "positive fitted bulk modulus"):
+            gruneisen._compute_lower(str(work_dir / "result.json"), task_dirs, result_paths)
+
+    def test_full_compute_lower_requires_task_results(self):
+        gruneisen = Gruneisen(
+            {
+                "type": "gruneisen",
+                "volume_strains": [-0.01, 0.0, 0.01],
+                "temperatures": [300],
+                "alpha_mode": "full",
+            }
+        )
+        work_dir = self.work_root / "gruneisen_missing_result"
+        task_dirs, _ = self._write_synthetic_gruneisen_tasks(
+            work_dir,
+            [
+                (-0.01, 99.0, [[4.2, 8.4]], -4.0),
+                (0.0, 100.0, [[4.1, 8.2]], -4.0),
+                (0.01, 101.0, [[4.0, 8.0]], -4.0),
+            ],
+        )
+
+        with self.assertRaisesRegex(ValueError, "result_task.json"):
+            gruneisen._compute_lower(str(work_dir / "result.json"), task_dirs, [])
+
+    def test_primitive_compute_lower_requires_poscar_unitcell(self):
+        gruneisen = Gruneisen(
+            {
+                "type": "gruneisen",
+                "volume_strains": [-0.01, 0.0, 0.01],
+                "temperatures": [300],
+                "primitive": True,
+            }
+        )
+        work_dir = self.work_root / "gruneisen_missing_unitcell"
+        task_dirs, _ = self._write_synthetic_gruneisen_tasks(
+            work_dir,
+            [
+                (-0.01, 99.0, [[4.2, 8.4]], -4.0),
+                (0.0, 100.0, [[4.1, 8.2]], -4.0),
+                (0.01, 101.0, [[4.0, 8.0]], -4.0),
+            ],
+        )
+
+        with self.assertRaisesRegex(FileNotFoundError, "POSCAR-unitcell is required"):
+            gruneisen._compute_lower(str(work_dir / "result.json"), task_dirs, [])
+
+    def test_fit_birch_murnaghan_helper_is_side_effect_free(self):
+        fit = fit_birch_murnaghan(
+            [24.75, 25.0, 25.25],
+            [
+                -4.0 + 0.01 * (24.75 - 25.0) ** 2,
+                -4.0,
+                -4.0 + 0.01 * (25.25 - 25.0) ** 2,
+            ],
+            fixed_bp=4.0,
+        )
+        self.assertGreater(fit["K_T_GPa"], 0.0)
+        self.assertEqual(fit["fit_variant"], "fixed_bp")
+        self.assertEqual(fit["model"], "birch_murnaghan")
+
     def test_mode_heat_capacity_is_stable_for_large_x(self):
         cv = Gruneisen._mode_heat_capacity(frequency_thz=500.0, temperature=1.0)
         self.assertEqual(cv, 0.0)
+
+    def _write_synthetic_gruneisen_tasks(self, work_dir, synthetic, weight=1):
+        work_dir.mkdir(parents=True, exist_ok=True)
+        task_dirs = []
+        result_paths = []
+        for task_id, (strain, volume, frequencies, energy_per_atom) in enumerate(synthetic):
+            task_dir = work_dir / f"task.{task_id:06d}"
+            task_dir.mkdir(parents=True, exist_ok=True)
+            (task_dir / "volume.json").write_text(
+                json.dumps(
+                    {
+                        "strain": strain,
+                        "scale": 1.0,
+                        "volume": volume,
+                        "volume_per_atom": volume / 4.0,
+                        "reference_volume": 100.0,
+                        "reference_volume_per_atom": 25.0,
+                    }
+                )
+            )
+            mesh = {
+                "phonon": [
+                    {
+                        "q-position": [0.0, 0.0, 0.0],
+                        "weight": weight,
+                        "band": [{"frequency": freq} for freq in frequencies[0]],
+                    }
+                ]
+            }
+            (task_dir / "mesh.yaml").write_text(yaml.safe_dump(mesh, sort_keys=False))
+            result_path = task_dir / "result_task.json"
+            result_path.write_text(
+                json.dumps(
+                    {
+                        "energies": [energy_per_atom * 4.0],
+                        "atom_numbs": [4],
+                    }
+                )
+            )
+            task_dirs.append(str(task_dir))
+            result_paths.append(str(result_path))
+        return task_dirs, result_paths

--- a/tests/test_gruneisen.py
+++ b/tests/test_gruneisen.py
@@ -1,9 +1,11 @@
 import glob
+import os
 import shutil
 import tempfile
 import unittest
 from pathlib import Path
 import json
+from unittest.mock import patch
 
 import yaml
 
@@ -43,6 +45,7 @@ class TestGruneisen(unittest.TestCase):
         self.assertEqual(task_param["eos_model"], "birch_murnaghan")
         self.assertEqual(task_param["BAND_POINTS"], 51)
         self.assertEqual(task_param["supercell_size"], [2, 2, 2])
+        self.assertEqual(task_param["approach"], "linear")
 
     def test_validation_rejects_invalid_schema(self):
         with self.assertRaises(ValueError):
@@ -84,6 +87,8 @@ class TestGruneisen(unittest.TestCase):
         for task_dir, strain in zip(sorted(task_dirs), self.prop_param["volume_strains"]):
             self.assertTrue((Path(task_dir) / "POSCAR").is_file())
             self.assertTrue((Path(task_dir) / "POSCAR.orig").exists())
+            self.assertTrue((Path(task_dir) / "POSCAR-unitcell").is_file())
+            self.assertTrue((Path(task_dir) / "SPOSCAR").is_file())
             self.assertTrue((Path(task_dir) / "volume.json").is_file())
             volume_data = loadfn(Path(task_dir) / "volume.json")
             self.assertAlmostEqual(volume_data["strain"], strain)
@@ -92,6 +97,74 @@ class TestGruneisen(unittest.TestCase):
             self.assertTrue((Path(task_dir) / "band.conf").is_file())
 
         self.assertTrue((self.target_path / "band_path.json").is_file())
+
+    def test_vasp_displacement_gruneisen_is_explicitly_unsupported(self):
+        gruneisen = Gruneisen(
+            {
+                "type": "gruneisen",
+                "volume_strains": [-0.01, 0.0, 0.01],
+                "temperatures": [300],
+                "approach": "displacement",
+            },
+            inter_param={"type": "vasp"},
+        )
+        shutil.copy(self.source_path, self.equi_path / "CONTCAR")
+
+        with self.assertRaisesRegex(NotImplementedError, "approach='linear'"):
+            gruneisen.make_confs(str(self.target_path), str(self.equi_path))
+
+    def test_vasp_ensure_mesh_yaml_builds_force_constants_from_vasprun(self):
+        gruneisen = Gruneisen(
+            {
+                "type": "gruneisen",
+                "volume_strains": [-0.01, 0.0, 0.01],
+                "temperatures": [300],
+                "supercell_size": [1, 1, 1],
+            },
+            inter_param={"type": "vasp"},
+        )
+        task_dir = self.work_root / "vasp_mesh" / "task.000000"
+        task_dir.mkdir(parents=True)
+        (task_dir / "vasprun.xml").write_text("<modeling />\n")
+        (task_dir / "band.conf").write_text("MESH = 1 1 1\n")
+        (task_dir / "POSCAR-unitcell").write_text(self.source_path.read_text())
+        calls = []
+
+        def fake_check_call(command, shell):
+            self.assertTrue(shell)
+            calls.append(command)
+            if command == "phonopy --fc vasprun.xml":
+                (task_dir / "FORCE_CONSTANTS").write_text("fake force constants\n")
+            elif "POSCAR-unitcell" in command:
+                (task_dir / "mesh.yaml").write_text(
+                    yaml.safe_dump(
+                        {
+                            "phonon": [
+                                {
+                                    "q-position": [0.0, 0.0, 0.0],
+                                    "weight": 1,
+                                    "band": [{"frequency": 1.0}],
+                                }
+                            ]
+                        },
+                        sort_keys=False,
+                    )
+                )
+            else:
+                raise AssertionError(f"unexpected command: {command}")
+
+        cwd = os.getcwd()
+        try:
+            with patch("apex.core.property.Gruneisen.subprocess.check_call", side_effect=fake_check_call):
+                gruneisen._ensure_mesh_yaml(str(task_dir))
+        finally:
+            os.chdir(cwd)
+
+        self.assertTrue((task_dir / "FORCE_CONSTANTS").is_file())
+        self.assertTrue((task_dir / "mesh.yaml").is_file())
+        self.assertEqual(calls[0], "phonopy --fc vasprun.xml")
+        self.assertIn("-c POSCAR-unitcell", calls[1])
+        self.assertIn("--nomeshsym", calls[1])
 
     def test_post_process_prepares_phonon_run_inputs_for_lammps(self):
         deepmd_gruneisen = Gruneisen(
@@ -217,3 +290,7 @@ class TestGruneisen(unittest.TestCase):
         )
         self.assertTrue("Temperature(K)  SumGammaCv  Sign" in ptr)
         self.assertTrue("# contribution summary" in ptr)
+
+    def test_mode_heat_capacity_is_stable_for_large_x(self):
+        cv = Gruneisen._mode_heat_capacity(frequency_thz=500.0, temperature=1.0)
+        self.assertEqual(cv, 0.0)

--- a/tests/test_phonon.py
+++ b/tests/test_phonon.py
@@ -3,6 +3,7 @@ import os
 import shutil
 import sys
 import unittest
+from pathlib import Path
 
 import dpdata
 import numpy as np
@@ -16,6 +17,7 @@ __package__ = "tests"
 
 class TestPhonon(unittest.TestCase):
     def setUp(self):
+        tests_dir = Path(__file__).resolve().parent
         _jdata = {
             "structures": ["confs/std-bcc"],
             "interaction": {
@@ -28,13 +30,13 @@ class TestPhonon(unittest.TestCase):
                     "type": "phonon",
                     "skip": False,
                     "BAND": "0.0000 0.0000 0.5000  0.0000 0.0000 0.0000  0.5000 -0.5000 0.5000  0.25000 0.2500 0.2500  0 0 0",
-                    "supercell_matrix": [2, 2, 2]
+                    "supercell_size": [2, 2, 2]
                 },
             ],
         }
 
         self.equi_path = "confs/hp-Mo/relaxation/relax_task"
-        self.source_path = "equi/vasp"
+        self.source_path = tests_dir / "equi" / "vasp"
         self.target_path = "confs/hp-Mo/phonon_00"
         self.res_data = "output/phonon_00/result.json"
         self.ptr_data = "output/phonon_00/result.out"
@@ -65,13 +67,14 @@ class TestPhonon(unittest.TestCase):
 
     def test_task_param(self):
         self.assertEqual(self.prop_param[0], self.phonon.task_param())
+        self.assertEqual(self.phonon.task_param()["BAND_POINTS"], 51)
 
     def test_make_phonon_conf(self):
         if not os.path.exists(os.path.join(self.equi_path, "CONTCAR")):
             with self.assertRaises(RuntimeError):
                 self.phonon.make_confs(self.target_path, self.equi_path)
         shutil.copy(
-            os.path.join(self.source_path, "CONTCAR_Mo_bcc"),
+            self.source_path / "CONTCAR_Mo_bcc",
             os.path.join(self.equi_path, "CONTCAR"),
         )
         task_list = self.phonon.make_confs(self.target_path, self.equi_path)
@@ -79,3 +82,24 @@ class TestPhonon(unittest.TestCase):
         self.assertEqual(len(dfm_dirs), 1)
         self.assertTrue(os.path.isfile(os.path.join(self.target_path, "phonopy_disp.yaml")))
         self.assertTrue(os.path.isfile(os.path.join(self.target_path, "task.000000/band.conf")))
+
+    def test_post_process_injects_deepmd_plugin_for_phonon(self):
+        deepmd_phonon = Phonon(
+            {"type": "phonon", "supercell_size": [2, 2, 2]},
+            inter_param={"type": "deepmd"},
+        )
+        task_dir = Path("output/phonon_deepmd_post/task.000000")
+        shutil.rmtree(task_dir.parent, ignore_errors=True)
+        task_dir.mkdir(parents=True, exist_ok=True)
+        (task_dir / "in.lammps").write_text(
+            "clear\npair_style deepmd frozen_model.pth\npair_coeff * * Cu O\nrun 0\n"
+        )
+
+        try:
+            deepmd_phonon.post_process([str(task_dir)])
+            rewritten = (task_dir / "in.lammps").read_text()
+            self.assertIn("plugin load libdeepmd_lmp.so", rewritten)
+            self.assertIn("pair_style deepmd frozen_model.pth", rewritten)
+            self.assertNotIn("run 0", rewritten)
+        finally:
+            shutil.rmtree(task_dir.parent, ignore_errors=True)

--- a/tests/test_vasp.py
+++ b/tests/test_vasp.py
@@ -132,6 +132,36 @@ class TestVASP(unittest.TestCase):
         self.assertEqual(incar["ISIF"], 6)
         self.assertEqual(incar["KSPACING"], 0.01)
 
+    def test_make_input_file_gruneisen_linear_uses_dfpt_incar(self):
+        param = {
+            "type": "gruneisen",
+            "cal_type": "static",
+            "approach": "linear",
+            "cal_setting": {
+                "relax_pos": True,
+                "relax_shape": False,
+                "relax_vol": False,
+                "encut": 400,
+                "ediff": 1e-6,
+                "kspacing": 0.25,
+                "kgamma": False,
+            },
+        }
+        shutil.copy(
+            os.path.join(self.conf_path, "POSCAR"),
+            os.path.join(self.equi_path, "POSCAR"),
+        )
+
+        self.VASP.make_input_file(self.equi_path, "gruneisen", param)
+
+        incar = incar_upper(Incar.from_file(os.path.join(self.equi_path, "INCAR")))
+        self.assertEqual(incar["IBRION"], 8)
+        self.assertEqual(incar["NSW"], 1)
+        self.assertEqual(incar["ISIF"], 2)
+        self.assertEqual(incar["ENCUT"], 400)
+        self.assertEqual(incar["KSPACING"], 0.25)
+        self.assertFalse(incar["KGAMMA"])
+
     def test_compute(self):
         ret = self.VASP.compute(os.path.join(self.conf_path, "relaxation"))
         self.assertIsNone(ret)
@@ -160,3 +190,7 @@ class TestVASP(unittest.TestCase):
     def test_backward_files(self):
         backward_files = ["OUTCAR", "outlog", "CONTCAR", "OSZICAR", "XDATCAR"]
         self.assertEqual(self.VASP.backward_files(), backward_files)
+        self.assertEqual(
+            self.VASP.backward_files("gruneisen"),
+            ["OUTCAR", "outlog", "CONTCAR", "OSZICAR", "XDATCAR", "vasprun.xml"],
+        )


### PR DESCRIPTION
  ## Summary

This PR adds a new APEX `gruneisen` property workflow for phonon-based Gruneisen analysis and thermal-expansion estimation. The workflow computes phonons at multiple strained volumes, derives mode Gruneisen parameters from the volume dependence of phonon frequencies, and evaluates the heat-capacity-weighted Gruneisen sum over user-specified temperatures.

Two output modes are supported:
- `sign_only`: reports the weighted Gruneisen sum and its sign, intended for PTE/NTE classification.
- `full`: additionally fits a Birch-Murnaghan EOS from the strained volume-energy points, checks that the fitted bulk modulus is positive, and computes the volumetric thermal expansion coefficient `alpha_V(T)`.
  
## Key Changes
- Added the `gruneisen` property implementation with support for symmetric volume strain grids, phonon mesh/band postprocessing, mode-resolved Gruneisen parameters, temperature-dependent heat-capacity weighting, and skipped-mode accounting.
- Added LAMMPS/DPA-3 support through fixed-volume internal relaxation followed by phonoLAMMPS force-constant generation.
- Added VASP/DFT support for linear-response phonon Gruneisen workflows, including `FORCE_CONSTANTS` extraction and full-mode postprocessing.
- Added EOS fitting utilities for Birch-Murnaghan bulk-modulus estimation used by `alpha_mode = "full"`.
- Updated calculator backward files so Gruneisen full mode can retrieve the logs and task outputs needed for energy extraction and postprocessing.
- Added tests covering Gruneisen schema validation, sign-only behavior, full-mode thermal expansion, EOS fitting, positive bulk-modulus requirements, and relevant LAMMPS/VASP integration paths.
- Updated documentation with a README property reference and a standalone workflow note describing the Gruneisen calculation flow.

## Validation
The implementation was validated with focused unit tests and several end-to-end APEX/Bohrium runs:
- LAMMPS + DPA-3 Cu control workflow comparing:
  - finite-temperature NPT `finitetlatt`
  - Gruneisen `alpha_mode = "full"`
  - VASP/DFT Cu Gruneisen workflow using a `2x2x2` DFPT phonon supercell and `LREAL = .FALSE.`

For the Cu control case, FiniteTlatt, LAMMPS/DPA-3 Gruneisen, VASP/DFT Gruneisen, and the dataset reference all predict positive thermal expansion with the same order of magnitude.

## Notes

The first-version full CTE path intentionally keeps a narrow scope:
- `volume_strains` must be symmetric and include `0.0`.
- `bulk_modulus_source` is currently `eos_fit`.
- `eos_model` is currently `birch_murnaghan`.
- `full` mode requires fixed-volume internal relaxation semantics:
  - `relax_pos = true`
  - `relax_shape = false`
  - `relax_vol = false`

A successful remote workflow status is not treated as sufficient scientific validation; downstream checks inspect `result.json`, skipped-mode counts, phonon frequencies, `FORCE_CONSTANTS`, `mesh.yaml`, and `band.yaml`.