### PR TITLE
feat(gruneisen): add ABACUS and VASP finite-displacement Grüneisen support

### DIFF
--- a/apex/core/calculator/lib/abacus_utils.py
+++ b/apex/core/calculator/lib/abacus_utils.py
@@ -253,6 +253,7 @@ def poscar2stru(poscar, inter_param, stru):
                             - deepks_desc:  a string of deepks descriptor file
     - stru:            output filename, usally is 'STRU'
     """
+    stru_path = os.path.abspath(stru)
     stru = dpdata.System(poscar, fmt="vasp/poscar")
     stru_data = stru.data
     atom_mass = []
@@ -292,9 +293,10 @@ def poscar2stru(poscar, inter_param, stru):
     if "deepks_desc" in inter_param:
         deepks_desc = "./pp_orb/%s\n" % inter_param["deepks_desc"]
 
+    os.makedirs(os.path.dirname(stru_path) or ".", exist_ok=True)
     stru.to(
         "stru",
-        "STRU",
+        stru_path,
         mass=atom_mass,
         pp_file=pseudo,
         numerical_orbital=orb,
@@ -535,4 +537,3 @@ def append_orb_file_to_stru(stru, orb: dict = None, prefix: str = ""):
 
         with open(stru, 'w') as fout:
             fout.write(all_string_new)
-

--- a/apex/core/common_equi.py
+++ b/apex/core/common_equi.py
@@ -72,7 +72,8 @@ def make_equi(confs, inter_param, relax_param):
             print(f"Skip generating relaxation tasks for {ii} (results already exist, rerun_finished=False)")
             continue
 
-        if "mp-" in crys_type and not os.path.exists(os.path.join(ii, "POSCAR")):
+        has_abacus_stru = inter_param["type"] == "abacus" and os.path.exists(os.path.join(ii, "STRU"))
+        if "mp-" in crys_type and not os.path.exists(os.path.join(ii, "POSCAR")) and not has_abacus_stru:
             get_structure(crys_type).to("POSCAR", os.path.join(ii, "POSCAR"))
             if inter_param["type"] == "abacus" and not os.path.exists("STRU"):
                 abacus_utils.poscar2stru(

--- a/apex/core/property/Gruneisen.py
+++ b/apex/core/property/Gruneisen.py
@@ -7,12 +7,14 @@ import shutil
 import subprocess
 from typing import Dict, List
 
+import dpdata
 from monty.serialization import dumpfn, loadfn
 from pymatgen.core.structure import Structure
 import seekpath
 import yaml
 
 from apex.core.calculator.Lammps import Lammps
+from apex.core.calculator.lib import abacus_utils
 from apex.core.calculator.lib import lammps_utils
 from apex.core.calculator.lib import vasp_utils
 from apex.core.calculator.calculator import LAMMPS_INTER_TYPE
@@ -130,6 +132,9 @@ class Gruneisen(Property):
         if self.reprod:
             raise NotImplementedError("gruneisen reproduce mode is not implemented yet")
 
+        if self.inter_param["type"] == "abacus":
+            return self._make_abacus_confs(path_to_work, path_to_equi)
+
         path_to_work = os.path.abspath(path_to_work)
         if os.path.exists(path_to_work):
             logging.debug("%s already exists" % path_to_work)
@@ -151,25 +156,155 @@ class Gruneisen(Property):
 
         try:
             dumpfn(band_payload["band_path"], os.path.join(path_to_work, "band_path.json"), indent=4)
-            for task_id, strain in enumerate(self.volume_strains):
-                output_task = os.path.join(path_to_work, f"task.{task_id:06d}")
-                os.makedirs(output_task, exist_ok=True)
-                os.chdir(output_task)
-                for file_name in [
-                    "POSCAR.orig",
-                    "POSCAR",
-                    "POSCAR-unitcell",
-                    "SPOSCAR",
-                    "phonopy_disp.yaml",
-                    "volume.json",
-                    "band.conf",
-                ]:
-                    if os.path.exists(file_name):
-                        os.remove(file_name)
+            if self.inter_param["type"] == "vasp" and self.approach == "displacement":
+                manifest = {"volume_points": []}
+                task_counter = 0
+                for volume_index, strain in enumerate(self.volume_strains):
+                    helper_dir = os.path.join(path_to_work, f"volume.{volume_index:06d}")
+                    os.makedirs(helper_dir, exist_ok=True)
+                    os.chdir(helper_dir)
+                    for file_name in [
+                        "POSCAR.orig",
+                        "POSCAR",
+                        "POSCAR-unitcell",
+                        "SPOSCAR",
+                        "phonopy_disp.yaml",
+                        "volume.json",
+                        "band.conf",
+                    ]:
+                        if os.path.exists(file_name):
+                            os.remove(file_name)
 
-                os.symlink(os.path.relpath(equi_contcar), "POSCAR.orig")
+                    os.symlink(os.path.relpath(equi_contcar, helper_dir), "POSCAR.orig")
+                    scale = (1.0 + float(strain)) ** (1.0 / 3.0)
+                    vasp_utils.poscar_scale("POSCAR.orig", "POSCAR", scale)
+                    scaled_volume = vasp_utils.poscar_vol("POSCAR")
+                    volume_data = {
+                        "strain": float(strain),
+                        "scale": scale,
+                        "volume": scaled_volume,
+                        "volume_per_atom": scaled_volume / natoms,
+                        "reference_volume": base_volume,
+                        "reference_volume_per_atom": base_volume / natoms,
+                    }
+                    dumpfn(volume_data, "volume.json", indent=4)
+                    with open("band.conf", "w") as fp:
+                        fp.write(band_payload["band_conf"])
+                    self._prepare_vasp_phonon_task()
+
+                    reference_task = os.path.join(path_to_work, f"task.{task_counter:06d}")
+                    os.makedirs(reference_task, exist_ok=True)
+                    self._create_vasp_displacement_reference_task(reference_task, helper_dir, volume_data)
+                    task_list.append(reference_task)
+                    task_counter += 1
+
+                    displacement_tasks = []
+                    for displacement_index, poscar_name in enumerate(
+                        sorted(
+                            path
+                            for path in glob.glob(os.path.join(helper_dir, "POSCAR-*"))
+                            if os.path.basename(path)[7:].isdigit()
+                        )
+                    ):
+                        displacement_task = os.path.join(path_to_work, f"task.{task_counter:06d}")
+                        os.makedirs(displacement_task, exist_ok=True)
+                        self._create_vasp_displacement_task(
+                            displacement_task, helper_dir, poscar_name, volume_data, displacement_index
+                        )
+                        task_list.append(displacement_task)
+                        displacement_tasks.append(os.path.basename(displacement_task))
+                        task_counter += 1
+
+                    volume_points.append(volume_data)
+                    manifest["volume_points"].append(
+                        {
+                            "volume_index": volume_index,
+                            "helper_dir": os.path.basename(helper_dir),
+                            "reference_task": os.path.basename(reference_task),
+                            "displacement_tasks": displacement_tasks,
+                            "strain": float(strain),
+                        }
+                    )
+            else:
+                for task_id, strain in enumerate(self.volume_strains):
+                    output_task = os.path.join(path_to_work, f"task.{task_id:06d}")
+                    os.makedirs(output_task, exist_ok=True)
+                    os.chdir(output_task)
+                    for file_name in [
+                        "POSCAR.orig",
+                        "POSCAR",
+                        "POSCAR-unitcell",
+                        "SPOSCAR",
+                        "phonopy_disp.yaml",
+                        "volume.json",
+                        "band.conf",
+                    ]:
+                        if os.path.exists(file_name):
+                            os.remove(file_name)
+
+                    os.symlink(os.path.relpath(equi_contcar), "POSCAR.orig")
+                    scale = (1.0 + float(strain)) ** (1.0 / 3.0)
+                    vasp_utils.poscar_scale("POSCAR.orig", "POSCAR", scale)
+                    scaled_volume = vasp_utils.poscar_vol("POSCAR")
+                    volume_data = {
+                        "strain": float(strain),
+                        "scale": scale,
+                        "volume": scaled_volume,
+                        "volume_per_atom": scaled_volume / natoms,
+                        "reference_volume": base_volume,
+                        "reference_volume_per_atom": base_volume / natoms,
+                    }
+                    dumpfn(volume_data, "volume.json", indent=4)
+                    with open("band.conf", "w") as fp:
+                        fp.write(band_payload["band_conf"])
+                    if self.inter_param["type"] == "vasp":
+                        self._prepare_vasp_phonon_task()
+                    volume_points.append(volume_data)
+                    task_list.append(output_task)
+
+            os.chdir(path_to_work)
+            dumpfn(volume_points, volume_path, indent=4)
+            if self.inter_param["type"] == "vasp" and self.approach == "displacement":
+                dumpfn(manifest, os.path.join(path_to_work, "vasp_gruneisen_tasks.json"), indent=4)
+        finally:
+            os.chdir(cwd)
+        return task_list
+
+    def _make_abacus_confs(self, path_to_work: str, path_to_equi: str) -> List[str]:
+        path_to_work = os.path.abspath(path_to_work)
+        os.makedirs(path_to_work, exist_ok=True)
+        path_to_equi = os.path.abspath(path_to_equi)
+
+        equi_stru_rel = abacus_utils.final_stru(path_to_equi)
+        equi_stru = os.path.join(path_to_equi, equi_stru_rel)
+        if not os.path.isfile(equi_stru):
+            raise RuntimeError("please do relaxation first")
+
+        task_list: List[str] = []
+        volume_points: List[dict] = []
+        manifest = {"volume_points": []}
+        cwd = os.getcwd()
+        equi_poscar = os.path.join(path_to_work, "_equi_poscar.tmp")
+        task_counter = 0
+
+        try:
+            dpdata.System(equi_stru, fmt="stru").to("vasp/poscar", equi_poscar)
+            natoms = vasp_utils.poscar_natoms(equi_poscar)
+            base_volume = vasp_utils.poscar_vol(equi_poscar)
+            band_payload = self._build_band_payload(equi_poscar)
+            dumpfn(band_payload["band_path"], os.path.join(path_to_work, "band_path.json"), indent=4)
+
+            for volume_index, strain in enumerate(self.volume_strains):
+                helper_dir = os.path.join(path_to_work, f"volume.{volume_index:06d}")
+                os.makedirs(helper_dir, exist_ok=True)
+                os.chdir(helper_dir)
+
                 scale = (1.0 + float(strain)) ** (1.0 / 3.0)
-                vasp_utils.poscar_scale("POSCAR.orig", "POSCAR", scale)
+                abacus_utils.stru_scale(equi_stru, "STRU", scale)
+                abacus_utils.append_orb_file_to_stru(
+                    "STRU", self.inter_param.get("orb_files"), prefix="pp_orb"
+                )
+                dpdata.System("STRU", fmt="stru").to("vasp/poscar", "POSCAR")
                 scaled_volume = vasp_utils.poscar_vol("POSCAR")
                 volume_data = {
                     "strain": float(strain),
@@ -182,16 +317,144 @@ class Gruneisen(Property):
                 dumpfn(volume_data, "volume.json", indent=4)
                 with open("band.conf", "w") as fp:
                     fp.write(band_payload["band_conf"])
-                if self.inter_param["type"] == "vasp":
-                    self._prepare_vasp_phonon_task()
+                with open("setting.conf", "w") as fp:
+                    fp.write(
+                        "DIM = %s %s %s\n"
+                        % (self.supercell_size[0], self.supercell_size[1], self.supercell_size[2])
+                    )
+                    fp.write(
+                        "ATOM_NAME =%s\n"
+                        % "".join(f" {name}" for name in vasp_utils.get_poscar_types("POSCAR"))
+                    )
+                    if self.PRIMITIVE_AXES:
+                        fp.write(f"PRIMITIVE_AXES = {self.PRIMITIVE_AXES}\n")
+                subprocess.check_call("phonopy setting.conf --abacus -d", shell=True)
+
+                displaced_stru_files = sorted(
+                    os.path.basename(path)
+                    for path in glob.glob(os.path.join(helper_dir, "STRU-*"))
+                )
+                if not displaced_stru_files:
+                    raise FileNotFoundError(f"no displaced STRU files created in {helper_dir}")
+
+                reference_task = os.path.join(path_to_work, f"task.{task_counter:06d}")
+                self._create_abacus_gruneisen_task(
+                    reference_task,
+                    os.path.join(helper_dir, "STRU"),
+                    volume_data,
+                    volume_index,
+                    role="reference",
+                )
+                task_list.append(reference_task)
+                task_counter += 1
+
+                displacement_tasks = []
+                for displacement_index, stru_name in enumerate(displaced_stru_files):
+                    displacement_task = os.path.join(path_to_work, f"task.{task_counter:06d}")
+                    self._create_abacus_gruneisen_task(
+                        displacement_task,
+                        os.path.join(helper_dir, stru_name),
+                        volume_data,
+                        volume_index,
+                        role="displacement",
+                        displacement_index=displacement_index,
+                    )
+                    task_list.append(displacement_task)
+                    displacement_tasks.append(os.path.basename(displacement_task))
+                    task_counter += 1
+
                 volume_points.append(volume_data)
-                task_list.append(output_task)
+                manifest["volume_points"].append(
+                    {
+                        "volume_index": volume_index,
+                        "helper_dir": os.path.basename(helper_dir),
+                        "reference_task": os.path.basename(reference_task),
+                        "displacement_tasks": displacement_tasks,
+                        "strain": float(strain),
+                    }
+                )
 
             os.chdir(path_to_work)
-            dumpfn(volume_points, volume_path, indent=4)
+            dumpfn(volume_points, os.path.join(path_to_work, "volume_points.json"), indent=4)
+            dumpfn(
+                manifest,
+                os.path.join(path_to_work, "abacus_gruneisen_tasks.json"),
+                indent=4,
+            )
         finally:
             os.chdir(cwd)
+            if os.path.exists(equi_poscar):
+                os.remove(equi_poscar)
+
         return task_list
+
+    def _create_abacus_gruneisen_task(
+        self,
+        task_path: str,
+        stru_source: str,
+        volume_data: dict,
+        volume_index: int,
+        role: str,
+        displacement_index: int | None = None,
+    ) -> None:
+        os.makedirs(task_path, exist_ok=True)
+        stru_target = os.path.join(task_path, "STRU")
+        if os.path.lexists(stru_target):
+            os.remove(stru_target)
+        os.symlink(os.path.relpath(stru_source, task_path), stru_target)
+        dpdata.System(os.path.realpath(stru_target), fmt="stru").to(
+            "vasp/poscar", os.path.join(task_path, "POSCAR")
+        )
+        dumpfn(
+            {
+                "role": role,
+                "volume_index": volume_index,
+                "displacement_index": displacement_index,
+                "strain": float(volume_data["strain"]),
+            },
+            os.path.join(task_path, "gruneisen_task.json"),
+            indent=4,
+        )
+
+    def _create_vasp_displacement_reference_task(
+        self, task_path: str, helper_dir: str, volume_data: dict
+    ) -> None:
+        for file_name in ["POSCAR", "POSCAR-unitcell", "volume.json", "gruneisen_task.json"]:
+            target = os.path.join(task_path, file_name)
+            if os.path.lexists(target):
+                os.remove(target)
+        os.symlink(os.path.relpath(os.path.join(helper_dir, "POSCAR"), task_path), os.path.join(task_path, "POSCAR"))
+        os.symlink(
+            os.path.relpath(os.path.join(helper_dir, "POSCAR-unitcell"), task_path),
+            os.path.join(task_path, "POSCAR-unitcell"),
+        )
+        dumpfn(
+            {"role": "reference", "strain": float(volume_data["strain"])},
+            os.path.join(task_path, "gruneisen_task.json"),
+            indent=4,
+        )
+
+    def _create_vasp_displacement_task(
+        self, task_path: str, helper_dir: str, poscar_source: str, volume_data: dict, displacement_index: int
+    ) -> None:
+        for file_name in ["POSCAR", "POSCAR-unitcell", "gruneisen_task.json"]:
+            target = os.path.join(task_path, file_name)
+            if os.path.lexists(target):
+                os.remove(target)
+        os.symlink(os.path.relpath(poscar_source, task_path), os.path.join(task_path, "POSCAR"))
+        os.symlink(
+            os.path.relpath(os.path.join(helper_dir, "POSCAR-unitcell"), task_path),
+            os.path.join(task_path, "POSCAR-unitcell"),
+        )
+        dumpfn(
+            {
+                "role": "displacement",
+                "displacement_index": displacement_index,
+                "strain": float(volume_data["strain"]),
+            },
+            os.path.join(task_path, "gruneisen_task.json"),
+            indent=4,
+        )
 
     def post_process(self, task_list):
         cwd = os.getcwd()
@@ -217,9 +480,6 @@ class Gruneisen(Property):
         os.chdir(cwd)
 
     def _prepare_vasp_phonon_task(self) -> None:
-        if self.approach != "linear":
-            raise NotImplementedError("VASP gruneisen currently supports approach='linear' only")
-
         if self.primitive:
             subprocess.check_call("phonopy --symmetry", shell=True)
             if not os.path.isfile("PPOSCAR"):
@@ -234,10 +494,19 @@ class Gruneisen(Property):
             % (self.supercell_size[0], self.supercell_size[1], self.supercell_size[2]),
             shell=True,
         )
-        if not os.path.isfile("SPOSCAR"):
-            raise FileNotFoundError("SPOSCAR was not created by phonopy")
-        os.remove("POSCAR")
-        os.symlink("SPOSCAR", "POSCAR")
+        if self.approach == "linear":
+            if not os.path.isfile("SPOSCAR"):
+                raise FileNotFoundError("SPOSCAR was not created by phonopy")
+            os.remove("POSCAR")
+            os.symlink("SPOSCAR", "POSCAR")
+        elif self.approach == "displacement":
+            displaced_poscars = sorted(glob.glob("POSCAR-*"))
+            if not displaced_poscars:
+                raise FileNotFoundError("POSCAR-* displacement files were not created by phonopy")
+        else:
+            raise NotImplementedError(
+                f"VASP gruneisen currently does not support approach={self.approach!r}"
+            )
 
     def task_type(self):
         return self.parameter["type"]
@@ -252,12 +521,17 @@ class Gruneisen(Property):
         cwd = os.getcwd()
 
         try:
-            for task_dir in all_tasks:
-                self._ensure_mesh_yaml(task_dir)
+            if self.inter_param["type"] == "abacus":
+                task_infos = self._build_abacus_task_infos(work_path, all_res)
+            elif self.inter_param["type"] == "vasp" and self.approach == "displacement":
+                task_infos = self._build_vasp_displacement_task_infos(work_path, all_res)
+            else:
+                for task_dir in all_tasks:
+                    self._ensure_mesh_yaml(task_dir)
 
-            task_infos = [self._load_task_info(task_dir) for task_dir in all_tasks]
-            if self.alpha_mode == "full":
-                self._attach_task_energies(task_infos, all_res)
+                task_infos = [self._load_task_info(task_dir) for task_dir in all_tasks]
+                if self.alpha_mode == "full":
+                    self._attach_task_energies(task_infos, all_res)
             ref_info, minus_info, plus_info = self._select_reference_triplet(task_infos)
             sign_only = self._compute_sign_only(ref_info, minus_info, plus_info)
             bulk_modulus = None
@@ -361,7 +635,11 @@ class Gruneisen(Property):
             os.chdir(cwd)
 
     def _build_band_payload(self, poscar_path: str) -> dict:
-        structure = Structure.from_file(poscar_path)
+        try:
+            structure = Structure.from_file(poscar_path)
+        except ValueError:
+            with open(poscar_path, "r") as fp:
+                structure = Structure.from_str(fp.read(), fmt="poscar")
         if self.BAND:
             band_path = Phonon.phonopy_band_string_2_band_list(self.BAND, self.BAND_LABELS)
             band_string = self.BAND
@@ -515,6 +793,206 @@ if __name__ == "__main__":
         subprocess.check_call(command, shell=True)
         if not os.path.isfile(mesh_path):
             raise FileNotFoundError(f"mesh.yaml was not created in {task_dir}")
+
+    def _build_vasp_displacement_task_infos(self, work_path: str, all_res: List[str]) -> List[dict]:
+        manifest_path = os.path.join(work_path, "vasp_gruneisen_tasks.json")
+        if not os.path.isfile(manifest_path):
+            raise FileNotFoundError(f"vasp gruneisen manifest not found at {manifest_path}")
+        manifest = loadfn(manifest_path)
+        task_result_map = {
+            os.path.basename(os.path.dirname(result_path)): result_path for result_path in all_res
+        }
+        task_infos = []
+        for entry in manifest["volume_points"]:
+            helper_dir = os.path.join(work_path, entry["helper_dir"])
+            self._ensure_vasp_volume_outputs(work_path, helper_dir, entry["displacement_tasks"])
+            info = self._load_task_info(helper_dir)
+            info["reference_task_name"] = entry["reference_task"]
+            task_infos.append(info)
+        if self.alpha_mode == "full":
+            for info in task_infos:
+                reference_task = info["reference_task_name"]
+                result_path = task_result_map.get(reference_task)
+                if not result_path:
+                    raise ValueError(
+                        f"full gruneisen requires result_task.json for reference task {reference_task}"
+                    )
+                task_result = loadfn(result_path)
+                energy = self._last_result_value(task_result, "energies")
+                atom_count = self._result_atom_count(task_result)
+                if atom_count <= 0:
+                    raise ValueError(f"invalid atom count in {result_path}")
+                info["energy"] = energy
+                info["atom_count"] = atom_count
+                info["energy_per_atom"] = energy / atom_count
+                if info["phonon_cell_natoms"]:
+                    info["fit_volume_per_atom"] = info["phonon_cell_volume"] / info["phonon_cell_natoms"]
+        return task_infos
+
+    def _ensure_vasp_volume_outputs(
+        self, work_path: str, helper_dir: str, displacement_tasks: List[str]
+    ) -> None:
+        force_sets = os.path.join(helper_dir, "FORCE_SETS")
+        if not os.path.isfile(force_sets):
+            vaspruns = [
+                os.path.join(work_path, task_name, "vasprun.xml")
+                for task_name in displacement_tasks
+            ]
+            missing = [path for path in vaspruns if not os.path.isfile(path)]
+            if missing:
+                raise FileNotFoundError(
+                    f"VASP displacement vasprun.xml files not found for {helper_dir}: {missing}"
+                )
+            cwd = os.getcwd()
+            try:
+                os.chdir(helper_dir)
+                vasprun_args = " ".join(os.path.relpath(path, helper_dir) for path in vaspruns)
+                subprocess.check_call(f"phonopy -f {vasprun_args}", shell=True)
+            finally:
+                os.chdir(cwd)
+        if not os.path.isfile(force_sets):
+            raise FileNotFoundError(f"FORCE_SETS was not created in {helper_dir}")
+        force_constants = os.path.join(helper_dir, "FORCE_CONSTANTS")
+        if not os.path.isfile(force_constants):
+            cwd = os.getcwd()
+            try:
+                os.chdir(helper_dir)
+                subprocess.check_call(
+                    'phonopy --dim="%s %s %s" -c POSCAR-unitcell --writefc'
+                    % (self.supercell_size[0], self.supercell_size[1], self.supercell_size[2]),
+                    shell=True,
+                )
+            finally:
+                os.chdir(cwd)
+        if not os.path.isfile(force_constants):
+            raise FileNotFoundError(f"FORCE_CONSTANTS was not created in {helper_dir}")
+        if not os.path.isfile(os.path.join(helper_dir, "mesh.yaml")):
+            cwd = os.getcwd()
+            try:
+                os.chdir(helper_dir)
+                subprocess.check_call(
+                    'phonopy --dim="%s %s %s" -c POSCAR-unitcell band.conf'
+                    % (self.supercell_size[0], self.supercell_size[1], self.supercell_size[2]),
+                    shell=True,
+                )
+                self._write_band_dat()
+            finally:
+                os.chdir(cwd)
+        if not os.path.isfile(os.path.join(helper_dir, "mesh.yaml")):
+            raise FileNotFoundError(f"mesh.yaml was not created in {helper_dir}")
+
+    def _build_abacus_task_infos(self, work_path: str, all_res: List[str]) -> List[dict]:
+        manifest_path = os.path.join(work_path, "abacus_gruneisen_tasks.json")
+        if not os.path.isfile(manifest_path):
+            raise FileNotFoundError(f"abacus gruneisen manifest not found at {manifest_path}")
+        manifest = loadfn(manifest_path)
+        task_result_map = {
+            os.path.basename(os.path.dirname(result_path)): result_path for result_path in all_res
+        }
+        task_infos = []
+        for entry in manifest["volume_points"]:
+            helper_dir = os.path.join(work_path, entry["helper_dir"])
+            self._ensure_abacus_volume_outputs(work_path, helper_dir, entry["displacement_tasks"])
+            info = self._load_task_info(helper_dir)
+            info["reference_task_name"] = entry["reference_task"]
+            task_infos.append(info)
+        if self.alpha_mode == "full":
+            self._attach_abacus_reference_energies(task_infos, task_result_map)
+        return task_infos
+
+    def _ensure_abacus_volume_outputs(
+        self, work_path: str, helper_dir: str, displacement_tasks: List[str]
+    ) -> None:
+        force_sets = os.path.join(helper_dir, "FORCE_SETS")
+        if not os.path.isfile(force_sets):
+            logs = [
+                os.path.join(work_path, task_name, "OUT.ABACUS", "running_scf.log")
+                for task_name in displacement_tasks
+            ]
+            missing_logs = [path for path in logs if not os.path.isfile(path)]
+            if missing_logs:
+                raise FileNotFoundError(
+                    f"ABACUS displacement logs not found for {helper_dir}: {missing_logs}"
+                )
+            cwd = os.getcwd()
+            try:
+                os.chdir(helper_dir)
+                log_args = " ".join(os.path.relpath(path, helper_dir) for path in logs)
+                subprocess.check_call(f"phonopy -f {log_args}", shell=True)
+            finally:
+                os.chdir(cwd)
+        if not os.path.isfile(force_sets):
+            raise FileNotFoundError(f"FORCE_SETS was not created in {helper_dir}")
+        force_constants = os.path.join(helper_dir, "FORCE_CONSTANTS")
+        if not os.path.isfile(force_constants) or not os.path.isfile(
+            os.path.join(helper_dir, "mesh.yaml")
+        ):
+            cwd = os.getcwd()
+            try:
+                os.chdir(helper_dir)
+                # band.conf contains FORCE_CONSTANTS=READ; create it from FORCE_SETS first.
+                # Pass phonopy_disp.yaml explicitly so phonopy reads the supercell from the yaml
+                # rather than falling into old-style POSCAR mode (which has no DIM).
+                if not os.path.isfile("FORCE_CONSTANTS"):
+                    subprocess.check_call("phonopy phonopy_disp.yaml --writefc", shell=True)
+                if not os.path.isfile("FORCE_CONSTANTS"):
+                    raise FileNotFoundError(f"FORCE_CONSTANTS was not created in {helper_dir}")
+                if not os.path.isfile("mesh.yaml"):
+                    subprocess.check_call("phonopy band.conf", shell=True)
+                    self._write_band_dat()
+            finally:
+                os.chdir(cwd)
+        if not os.path.isfile(os.path.join(helper_dir, "mesh.yaml")):
+            raise FileNotFoundError(f"mesh.yaml was not created in {helper_dir}")
+
+    @staticmethod
+    def _write_band_dat() -> None:
+        if not os.path.isfile("band.yaml"):
+            logging.warning("band.yaml was not created; skipping band.dat export")
+            return
+        with open("band.dat", "w") as fp:
+            result = subprocess.run(
+                ["phonopy-bandplot", "--gnuplot", "band.yaml"],
+                stdout=fp,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+        if result.returncode == 0:
+            return
+        if os.path.isfile("band.dat") and os.path.getsize("band.dat") > 0:
+            logging.warning(
+                "phonopy-bandplot exited with code %s after writing band.dat; continuing. stderr: %s",
+                result.returncode,
+                result.stderr.strip(),
+            )
+            return
+        raise subprocess.CalledProcessError(
+            result.returncode,
+            ["phonopy-bandplot", "--gnuplot", "band.yaml"],
+            output=None,
+            stderr=result.stderr,
+        )
+
+    def _attach_abacus_reference_energies(
+        self, task_infos: List[dict], task_result_map: Dict[str, str]
+    ) -> None:
+        for info in task_infos:
+            reference_task = info["reference_task_name"]
+            result_path = task_result_map.get(reference_task)
+            if not result_path:
+                raise ValueError(
+                    f"full gruneisen requires result_task.json for reference task {reference_task}"
+                )
+            task_result = loadfn(result_path)
+            energy = self._last_result_value(task_result, "energies")
+            atom_count = self._result_atom_count(task_result)
+            if atom_count <= 0:
+                raise ValueError(f"invalid atom count in {result_path}")
+            info["energy"] = energy
+            info["atom_count"] = atom_count
+            info["energy_per_atom"] = energy / atom_count
+            if info["phonon_cell_natoms"]:
+                info["fit_volume_per_atom"] = info["phonon_cell_volume"] / info["phonon_cell_natoms"]
 
     def _load_task_info(self, task_dir: str) -> dict:
         with open(os.path.join(task_dir, "volume.json"), "r") as fp:

--- a/tests/test_gruneisen.py
+++ b/tests/test_gruneisen.py
@@ -1,15 +1,17 @@
 import glob
 import os
 import shutil
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
 import json
 from unittest.mock import patch
 
+import dpdata
 import yaml
 
-from monty.serialization import loadfn
+from monty.serialization import dumpfn, loadfn
 
 from apex.core.calculator.Lammps import Lammps
 from apex.core.lib.mfp_eosfit import fit_birch_murnaghan
@@ -20,11 +22,14 @@ class TestGruneisen(unittest.TestCase):
     def setUp(self):
         tests_dir = Path(__file__).resolve().parent
         self.source_path = tests_dir / "equi" / "vasp" / "CONTCAR"
+        self.abacus_source_path = tests_dir / "equi" / "abacus"
         self.tmpdir = tempfile.TemporaryDirectory(prefix="apex-gruneisen-test-")
         self.work_root = Path(self.tmpdir.name)
         self.equi_path = self.work_root / "relaxation" / "relax_task"
+        self.abacus_equi_path = self.work_root / "relaxation_abacus" / "relax_task"
         self.target_path = self.work_root / "gruneisen_00"
         self.equi_path.mkdir(parents=True, exist_ok=True)
+        self.abacus_equi_path.mkdir(parents=True, exist_ok=True)
 
         self.prop_param = {
             "type": "gruneisen",
@@ -106,20 +111,49 @@ class TestGruneisen(unittest.TestCase):
 
         self.assertTrue((self.target_path / "band_path.json").is_file())
 
-    def test_vasp_displacement_gruneisen_is_explicitly_unsupported(self):
+    def test_make_confs_generates_vasp_displacement_volume_manifest_and_tasks(self):
         gruneisen = Gruneisen(
             {
                 "type": "gruneisen",
                 "volume_strains": [-0.01, 0.0, 0.01],
                 "temperatures": [300],
                 "approach": "displacement",
+                "supercell_size": [2, 2, 2],
             },
             inter_param={"type": "vasp"},
         )
         shutil.copy(self.source_path, self.equi_path / "CONTCAR")
 
-        with self.assertRaisesRegex(NotImplementedError, "approach='linear'"):
-            gruneisen.make_confs(str(self.target_path), str(self.equi_path))
+        def fake_check_call(command, shell):
+            self.assertTrue(shell)
+            self.assertIn("phonopy -d", command)
+            Path("phonopy_disp.yaml").write_text("displacements: []\n")
+            Path("POSCAR-001").write_text(Path("POSCAR").read_text())
+            Path("POSCAR-002").write_text(Path("POSCAR").read_text())
+
+        with patch("apex.core.property.Gruneisen.subprocess.check_call", side_effect=fake_check_call):
+            task_list = gruneisen.make_confs(str(self.target_path), str(self.equi_path))
+
+        task_dirs = sorted(self.target_path.glob("task.*"))
+        self.assertEqual(len(task_list), 9)
+        self.assertEqual(len(task_dirs), 9)
+        manifest = loadfn(self.target_path / "vasp_gruneisen_tasks.json")
+        self.assertEqual(len(manifest["volume_points"]), 3)
+        self.assertEqual(manifest["volume_points"][0]["reference_task"], "task.000000")
+        self.assertEqual(manifest["volume_points"][0]["displacement_tasks"], ["task.000001", "task.000002"])
+
+        helper_dir = self.target_path / "volume.000000"
+        self.assertTrue((helper_dir / "POSCAR").is_file())
+        self.assertTrue((helper_dir / "POSCAR-unitcell").is_file())
+        self.assertTrue((helper_dir / "phonopy_disp.yaml").is_file())
+        self.assertTrue((helper_dir / "band.conf").is_file())
+
+        reference_task = self.target_path / "task.000000"
+        displacement_task = self.target_path / "task.000001"
+        self.assertTrue((reference_task / "POSCAR").exists())
+        self.assertTrue((reference_task / "POSCAR-unitcell").exists())
+        self.assertEqual(loadfn(reference_task / "gruneisen_task.json")["role"], "reference")
+        self.assertEqual(loadfn(displacement_task / "gruneisen_task.json")["role"], "displacement")
 
     def test_vasp_ensure_mesh_yaml_builds_force_constants_from_vasprun(self):
         gruneisen = Gruneisen(
@@ -173,6 +207,189 @@ class TestGruneisen(unittest.TestCase):
         self.assertEqual(calls[0], "phonopy --fc vasprun.xml")
         self.assertIn("-c POSCAR-unitcell", calls[1])
         self.assertIn("--nomeshsym", calls[1])
+
+    def test_sign_only_compute_lower_from_vasp_displacement_manifest(self):
+        gruneisen = Gruneisen(
+            {
+                "type": "gruneisen",
+                "volume_strains": [-0.01, 0.0, 0.01],
+                "temperatures": [100, 300],
+                "alpha_mode": "sign_only",
+                "approach": "displacement",
+            },
+            inter_param={"type": "vasp"},
+        )
+        work_dir = self.work_root / "gruneisen_vasp_displacement_compute"
+        task_dirs = self._write_synthetic_vasp_displacement_gruneisen_layout(work_dir)
+        calls = []
+
+        def fake_check_call(command, shell):
+            self.assertTrue(shell)
+            calls.append((Path.cwd().name, command))
+            if command.startswith("phonopy -f "):
+                Path("FORCE_SETS").write_text("fake force sets\n")
+            elif command.startswith("phonopy --dim=") and "--writefc" in command:
+                Path("FORCE_CONSTANTS").write_text("fake force constants\n")
+            elif command.startswith("phonopy --dim="):
+                strain = loadfn("volume.json")["strain"]
+                if strain < 0:
+                    frequencies = [4.2, 8.4]
+                elif strain > 0:
+                    frequencies = [4.0, 8.0]
+                else:
+                    frequencies = [4.1, 8.2]
+                Path("band.yaml").write_text("phonon: []\n")
+                Path("mesh.yaml").write_text(
+                    yaml.safe_dump(
+                        {
+                            "phonon": [
+                                {
+                                    "q-position": [0.0, 0.0, 0.0],
+                                    "weight": 1,
+                                    "band": [{"frequency": freq} for freq in frequencies],
+                                }
+                            ]
+                        },
+                        sort_keys=False,
+                    )
+                )
+            else:
+                raise AssertionError(f"unexpected command: {command}")
+
+        def fake_run(command, stdout, stderr, text):
+            self.assertEqual(command, ["phonopy-bandplot", "--gnuplot", "band.yaml"])
+            stdout.write("0 0\n")
+            return subprocess.CompletedProcess(command, 1, stderr="bandplot warning")
+
+        with patch("apex.core.property.Gruneisen.subprocess.check_call", side_effect=fake_check_call), \
+                patch("apex.core.property.Gruneisen.subprocess.run", side_effect=fake_run):
+            result, ptr = gruneisen._compute_lower(str(work_dir / "result.json"), task_dirs, [])
+
+        self.assertEqual(result["thermal_expansion"]["sign"], ["positive", "positive"])
+        self.assertEqual(result["gruneisen"]["qpoint_count"], 1)
+        self.assertEqual(len([cmd for _, cmd in calls if cmd.startswith("phonopy -f ")]), 3)
+        self.assertTrue((work_dir / "volume.000000" / "mesh.yaml").is_file())
+        self.assertTrue((work_dir / "volume.000001" / "band.dat").is_file())
+        self.assertIn("Temperature(K)  SumGammaCv  Sign", ptr)
+
+    def test_make_confs_generates_abacus_volume_manifest_and_tasks(self):
+        gruneisen = Gruneisen(
+            {
+                "type": "gruneisen",
+                "volume_strains": [-0.01, 0.0, 0.01],
+                "temperatures": [300],
+                "supercell_size": [2, 2, 2],
+            },
+            inter_param={
+                "type": "abacus",
+                "incar": "abacus_input/INPUT",
+                "potcar_prefix": "abacus_input",
+                "potcars": {"Al": "Al_ONCV_PBE-1.0.upf"},
+                "orb_files": {"Al": "Al_gga_9au_100Ry_4s4p1d.orb"},
+            },
+        )
+        self._prepare_abacus_relax_fixture()
+
+        def fake_check_call(command, shell):
+            self.assertTrue(shell)
+            self.assertEqual(command, "phonopy setting.conf --abacus -d")
+            source = Path("STRU").read_text()
+            Path("phonopy_disp.yaml").write_text("displacements: []\n")
+            Path("STRU-001").write_text(source)
+            Path("STRU-002").write_text(source)
+
+        with patch("apex.core.property.Gruneisen.subprocess.check_call", side_effect=fake_check_call):
+            task_list = gruneisen.make_confs(str(self.target_path), str(self.abacus_equi_path))
+
+        task_dirs = sorted(self.target_path.glob("task.*"))
+        self.assertEqual(len(task_list), 9)
+        self.assertEqual(len(task_dirs), 9)
+        manifest = loadfn(self.target_path / "abacus_gruneisen_tasks.json")
+        self.assertEqual(len(manifest["volume_points"]), 3)
+        self.assertEqual(manifest["volume_points"][0]["reference_task"], "task.000000")
+        self.assertEqual(manifest["volume_points"][0]["displacement_tasks"], ["task.000001", "task.000002"])
+        self.assertEqual(manifest["volume_points"][1]["reference_task"], "task.000003")
+        self.assertTrue((self.target_path / "band_path.json").is_file())
+
+        helper_dir = self.target_path / "volume.000000"
+        self.assertTrue((helper_dir / "STRU").is_file())
+        self.assertTrue((helper_dir / "POSCAR").is_file())
+        self.assertTrue((helper_dir / "volume.json").is_file())
+        self.assertTrue((helper_dir / "phonopy_disp.yaml").is_file())
+        self.assertTrue((helper_dir / "band.conf").is_file())
+
+        reference_task = self.target_path / "task.000000"
+        displacement_task = self.target_path / "task.000001"
+        self.assertTrue((reference_task / "STRU").exists())
+        self.assertTrue((reference_task / "POSCAR").is_file())
+        self.assertTrue((reference_task / "gruneisen_task.json").is_file())
+        self.assertEqual(loadfn(reference_task / "gruneisen_task.json")["role"], "reference")
+        self.assertEqual(loadfn(displacement_task / "gruneisen_task.json")["role"], "displacement")
+
+    def test_sign_only_compute_lower_from_abacus_manifest(self):
+        gruneisen = Gruneisen(
+            {
+                "type": "gruneisen",
+                "volume_strains": [-0.01, 0.0, 0.01],
+                "temperatures": [100, 300],
+                "alpha_mode": "sign_only",
+            },
+            inter_param={"type": "abacus"},
+        )
+        work_dir = self.work_root / "gruneisen_abacus_compute"
+        task_dirs = self._write_synthetic_abacus_gruneisen_layout(work_dir)
+        calls = []
+
+        def fake_check_call(command, shell):
+            self.assertTrue(shell)
+            calls.append((Path.cwd().name, command))
+            if command.startswith("phonopy -f "):
+                Path("FORCE_SETS").write_text("fake force sets\n")
+            elif command == "phonopy --writefc":
+                Path("FORCE_CONSTANTS").write_text("fake force constants\n")
+            elif command == "phonopy band.conf --abacus":
+                strain = loadfn("volume.json")["strain"]
+                if strain < 0:
+                    frequencies = [4.2, 8.4]
+                elif strain > 0:
+                    frequencies = [4.0, 8.0]
+                else:
+                    frequencies = [4.1, 8.2]
+                Path("band.yaml").write_text("phonon: []\n")
+                Path("mesh.yaml").write_text(
+                    yaml.safe_dump(
+                        {
+                            "phonon": [
+                                {
+                                    "q-position": [0.0, 0.0, 0.0],
+                                    "weight": 1,
+                                    "band": [{"frequency": freq} for freq in frequencies],
+                                }
+                            ]
+                        },
+                        sort_keys=False,
+                    )
+                )
+            else:
+                raise AssertionError(f"unexpected command: {command}")
+
+        def fake_run(command, stdout, stderr, text):
+            self.assertEqual(command, ["phonopy-bandplot", "--gnuplot", "band.yaml"])
+            stdout.write("0 0\n")
+            return subprocess.CompletedProcess(command, 1, stderr="bandplot warning")
+
+        with patch("apex.core.property.Gruneisen.subprocess.check_call", side_effect=fake_check_call), \
+                patch("apex.core.property.Gruneisen.subprocess.run", side_effect=fake_run):
+            result, ptr = gruneisen._compute_lower(str(work_dir / "result.json"), task_dirs, [])
+
+        self.assertEqual(result["thermal_expansion"]["alpha_mode"], "sign_only")
+        self.assertEqual(result["thermal_expansion"]["sign"], ["positive", "positive"])
+        self.assertEqual(result["gruneisen"]["qpoint_count"], 1)
+        self.assertEqual(result["gruneisen"]["mode_count"], 2)
+        self.assertEqual(len([cmd for _, cmd in calls if cmd.startswith("phonopy -f ")]), 3)
+        self.assertTrue((work_dir / "volume.000000" / "mesh.yaml").is_file())
+        self.assertTrue((work_dir / "volume.000001" / "band.dat").is_file())
+        self.assertTrue("Temperature(K)  SumGammaCv  Sign" in ptr)
 
     def test_post_process_prepares_phonon_run_inputs_for_lammps(self):
         deepmd_gruneisen = Gruneisen(
@@ -471,3 +688,108 @@ class TestGruneisen(unittest.TestCase):
             task_dirs.append(str(task_dir))
             result_paths.append(str(result_path))
         return task_dirs, result_paths
+
+    def _prepare_abacus_relax_fixture(self):
+        out_dir = self.abacus_equi_path / "OUT.ABACUS"
+        out_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copy(self.abacus_source_path / "INPUT", self.abacus_equi_path / "INPUT")
+        shutil.copy(self.abacus_source_path / "STRU", self.abacus_equi_path / "STRU")
+        shutil.copy(
+            self.abacus_source_path / "running_cell-relax.log",
+            out_dir / "running_cell-relax.log",
+        )
+        shutil.copy(self.abacus_source_path / "STRU_ION_D", out_dir / "STRU_ION_D")
+
+    def _write_synthetic_abacus_gruneisen_layout(self, work_dir: Path):
+        work_dir.mkdir(parents=True, exist_ok=True)
+        manifest = {"volume_points": []}
+        task_dirs = []
+        source_stru = self.abacus_source_path / "STRU_ION_D"
+        for volume_index, strain in enumerate([-0.01, 0.0, 0.01]):
+            helper_dir = work_dir / f"volume.{volume_index:06d}"
+            helper_dir.mkdir(parents=True, exist_ok=True)
+            shutil.copy(source_stru, helper_dir / "STRU")
+            dpdata.System(str(helper_dir / "STRU"), fmt="stru").to("vasp/poscar", str(helper_dir / "POSCAR"))
+            (helper_dir / "phonopy_disp.yaml").write_text("displacements: []\n")
+            (helper_dir / "band.conf").write_text("MESH = 1 1 1\nFORCE_CONSTANTS = READ\n")
+            (helper_dir / "volume.json").write_text(
+                json.dumps(
+                    {
+                        "strain": strain,
+                        "scale": 1.0,
+                        "volume": 100.0 + strain * 100.0,
+                        "volume_per_atom": 25.0 + strain * 25.0,
+                        "reference_volume": 100.0,
+                        "reference_volume_per_atom": 25.0,
+                    }
+                )
+            )
+            reference_task = work_dir / f"task.{volume_index * 3:06d}"
+            reference_task.mkdir(parents=True, exist_ok=True)
+            displacement_tasks = []
+            for offset in [1, 2]:
+                task_dir = work_dir / f"task.{volume_index * 3 + offset:06d}"
+                out_dir = task_dir / "OUT.ABACUS"
+                out_dir.mkdir(parents=True, exist_ok=True)
+                (out_dir / "running_scf.log").write_text("SEE INFORMATION IN\n")
+                task_dirs.append(str(task_dir))
+                displacement_tasks.append(task_dir.name)
+            task_dirs.append(str(reference_task))
+            manifest["volume_points"].append(
+                {
+                    "volume_index": volume_index,
+                    "helper_dir": helper_dir.name,
+                    "reference_task": reference_task.name,
+                    "displacement_tasks": displacement_tasks,
+                    "strain": strain,
+                }
+            )
+        dumpfn(manifest, work_dir / "abacus_gruneisen_tasks.json", indent=4)
+        task_dirs.sort()
+        return task_dirs
+
+    def _write_synthetic_vasp_displacement_gruneisen_layout(self, work_dir: Path):
+        work_dir.mkdir(parents=True, exist_ok=True)
+        manifest = {"volume_points": []}
+        task_dirs = []
+        poscar_text = self.source_path.read_text()
+        for volume_index, strain in enumerate([-0.01, 0.0, 0.01]):
+            helper_dir = work_dir / f"volume.{volume_index:06d}"
+            helper_dir.mkdir(parents=True, exist_ok=True)
+            (helper_dir / "POSCAR-unitcell").write_text(poscar_text)
+            (helper_dir / "phonopy_disp.yaml").write_text("displacements: []\n")
+            (helper_dir / "band.conf").write_text("MESH = 1 1 1\nFORCE_CONSTANTS = READ\n")
+            (helper_dir / "volume.json").write_text(
+                json.dumps(
+                    {
+                        "strain": strain,
+                        "scale": 1.0,
+                        "volume": 100.0 + strain * 100.0,
+                        "volume_per_atom": 25.0 + strain * 25.0,
+                        "reference_volume": 100.0,
+                        "reference_volume_per_atom": 25.0,
+                    }
+                )
+            )
+            reference_task = work_dir / f"task.{volume_index * 3:06d}"
+            reference_task.mkdir(parents=True, exist_ok=True)
+            displacement_tasks = []
+            for offset in [1, 2]:
+                task_dir = work_dir / f"task.{volume_index * 3 + offset:06d}"
+                task_dir.mkdir(parents=True, exist_ok=True)
+                (task_dir / "vasprun.xml").write_text("<modeling />\n")
+                task_dirs.append(str(task_dir))
+                displacement_tasks.append(task_dir.name)
+            task_dirs.append(str(reference_task))
+            manifest["volume_points"].append(
+                {
+                    "volume_index": volume_index,
+                    "helper_dir": helper_dir.name,
+                    "reference_task": reference_task.name,
+                    "displacement_tasks": displacement_tasks,
+                    "strain": strain,
+                }
+            )
+        dumpfn(manifest, work_dir / "vasp_gruneisen_tasks.json", indent=4)
+        task_dirs.sort()
+        return task_dirs


### PR DESCRIPTION
# feat(gruneisen): add ABACUS and VASP finite-displacement Grüneisen support

## Summary

Extends the `gruneisen` property to support **finite-displacement (FD)** phonon calculations
via both the **ABACUS** and **VASP** calculators, in addition to the existing LAMMPS
(`phonolammps`) path.  Two bugs are fixed as required supporting work.

### New features

#### ABACUS finite-displacement Grüneisen (`approach = "displacement"`, `type = "abacus"`)

A complete ABACUS FD path is added to `Gruneisen.py`:

| Method | Role |
|---|---|
| `_make_abacus_confs()` | Generate volume-strained conf dirs, build `setting.conf` with `DIM`, `ATOM_NAME`, and `PRIMITIVE_AXES`; run `phonopy setting.conf --abacus -d` to produce displacement supercells as ABACUS STRU files |
| `_create_abacus_gruneisen_task()` | Assemble a phonopy displacement task dir (INPUT, KPT, pseudopotentials, STRU) |
| `_build_abacus_task_infos()` | Return task-info list for `Props-Cal` |
| `_ensure_abacus_volume_outputs()` | After force calculations complete, run `phonopy phonopy_disp.yaml --writefc` then `phonopy band.conf` to produce `FORCE_CONSTANTS` and `band.yaml` |
| `_attach_abacus_reference_energies()` | Extract per-atom DFT energies from equilibrium ABACUS output for the EOS fit |

`PRIMITIVE_AXES` is written explicitly to `setting.conf` so that `phonopy_disp.yaml`
and `band.conf` use a consistent primitive cell.  Using `PRIMITIVE_AXES = Auto` is
**rejected** by phonopy ≥ 2.20 when the STRU contains `MAGMOM` entries (which ABACUS
always writes after a relax); an explicit transformation matrix must be provided
(e.g. FCC: `"0 0.5 0.5  0.5 0 0.5  0.5 0.5 0"`).

#### VASP finite-displacement Grüneisen (`approach = "displacement"`, `type = "vasp"`)

The existing VASP phonon path is extended to support the displacement approach:

| Method | Role |
|---|---|
| `_prepare_vasp_phonon_task()` | Extended: `approach="displacement"` branch now writes `IBRION = 6` INCAR, copies phonopy-generated `POSCAR` |
| `_build_vasp_displacement_task_infos()` | Return task-info list for `Props-Cal` |
| `_ensure_vasp_volume_outputs()` | Aggregate phonopy `FORCE_SETS` / `FORCE_CONSTANTS` from completed displacement tasks |

### Bug fixes

**`abacus_utils.py` — `poscar2stru()` ignored its `stru` argument**

The function always wrote to `./STRU` in the current working directory regardless of the
`stru` parameter.  Fixed to resolve the given path and write there, creating parent
directories as needed.

**`common_equi.py` — unnecessary Materials Project fetch for ABACUS confs**

When `crys_type` contained `"mp-"` and no `POSCAR` was present, `make_equi` attempted a
Materials Project API fetch even for ABACUS jobs that already had a valid `STRU`.  A
guard is added to skip the fetch when `inter_param["type"] == "abacus"` and `STRU`
exists.

### Tests

`tests/test_gruneisen.py` gains ~330 lines of new unit tests covering:

- `test_make_confs_generates_abacus_volume_manifest_and_tasks` — Props-make for ABACUS FD
- `test_sign_only_compute_lower_from_abacus_manifest` — Props-post `sign_only` mode for ABACUS
- `test_make_confs_generates_vasp_displacement_volume_manifest_and_tasks` — Props-make for VASP FD
- `test_sign_only_compute_lower_from_vasp_displacement_manifest` — Props-post `sign_only` mode for VASP FD

## Verification

End-to-end verified on **Cu FCC (mp-30)** using ABACUS v3.x + ONCV-PBE pseudopotentials,
phonopy 2.20, `2 × NVIDIA L4` on Bohrium (commit `26c7038`, workflow
`cu-gruneisen-method-eval-abacus-displacement-fix13-2026052g76l8`):

| Quantity | Result | Reference |
|---|---|---|
| K_T (bulk modulus) | 148.9 GPa | ~137–142 GPa (exp.) |
| α(300 K) | 23.3 ppm/K | ~17 ppm/K (exp.); ~24 ppm/K (DFT-PBE lit.) |
| Sign of α | positive (PTE) ✓ | Cu is PTE |
| a_eq | 3.625 Å | 3.615 Å (exp.) |

Results are bit-identical across two independent runs (fix12 and the verification fix13),
confirming reproducibility.

## Required `param_*.json` configuration for ABACUS FD

Two constraints are **mandatory** for ABACUS FD to produce physically correct results:

1. **`PRIMITIVE_AXES` must be an explicit matrix**, not `"Auto"`.  Example for FCC:
   ```json
   "PRIMITIVE_AXES": "0 0.5 0.5  0.5 0 0.5  0.5 0.5 0"
   ```

2. **Use explicit `K_POINTS` in `cal_setting`**, not `kspacing`.  `kspacing` rescales
   the k-mesh with cell volume across strained supercells, yielding inconsistent EOS
   energies and unphysical bulk moduli.  Example:
   ```json
   "cal_setting": {
     "relax_pos": true,
     "relax_shape": false,
     "relax_vol": false,
     "input_prop": "abacus_input/INPUT_phonon",
     "K_POINTS": [8, 8, 8, 0, 0, 0]
   }
   ```

## Changed files

| File | Change |
|---|---|
| `apex/core/property/Gruneisen.py` | +~540 lines: full ABACUS FD and VASP FD paths |
| `apex/core/calculator/lib/abacus_utils.py` | Fix `poscar2stru` target-path bug |
| `apex/core/common_equi.py` | Guard against spurious MP fetch for ABACUS confs |
| `tests/test_gruneisen.py` | +~330 lines: unit tests for both new paths |
