### PR TITLE
Turn pytest to unitest

### DIFF
--- a/tests/test_annealing.py
+++ b/tests/test_annealing.py
@@ -1,4 +1,8 @@
+import os
 import shutil
+import tempfile
+import unittest
+from pathlib import Path
 
 import pytest
 from monty.serialization import loadfn
@@ -7,7 +11,9 @@ from apex.core.calculator.lib import lammps_utils
 from apex.core.property.Annealing import Annealing
 
 
-TEST_CONTCAR = "tests/equi/lammps/hcp-Ti-CONTCAR"
+TEST_CONTCAR = os.path.join(
+    os.path.dirname(__file__), "equi", "lammps", "hcp-Ti-CONTCAR"
+)
 TYPE_MAP = {"Ti": 0}
 PARAM = {"type": "deepmd"}
 
@@ -289,3 +295,34 @@ def test_annealing_lammps_input_contains_all_md_stages_and_outputs():
     assert "file cooling_interval.dat" in script
     assert "dump.anneal_ramp" in script
     assert "dump.anneal_cool" in script
+
+
+class TestAnnealingCoverage(unittest.TestCase):
+    def test_annealing_default_parameter_parsing(self):
+        test_annealing_default_parameter_parsing()
+
+    def test_annealing_custom_cal_setting_override(self):
+        test_annealing_custom_cal_setting_override()
+
+    def test_annealing_make_confs_writes_task_files_and_variables(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            test_annealing_make_confs_writes_task_files_and_variables(Path(tmp))
+
+    def test_annealing_supercell_length_derives_replication_and_task_param(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            test_annealing_supercell_length_derives_replication_and_task_param(Path(tmp))
+
+    def test_annealing_rate_controls_derive_ramp_and_cool_steps(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            test_annealing_rate_controls_derive_ramp_and_cool_steps(Path(tmp))
+
+    def test_annealing_rate_fallback_and_missing_relaxation_error(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            test_annealing_rate_fallback_and_missing_relaxation_error(Path(tmp))
+
+    def test_annealing_compute_lower_returns_task_notes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            test_annealing_compute_lower_returns_task_notes(Path(tmp))
+
+    def test_annealing_lammps_input_contains_all_md_stages_and_outputs(self):
+        test_annealing_lammps_input_contains_all_md_stages_and_outputs()

--- a/tests/test_finitetelastic.py
+++ b/tests/test_finitetelastic.py
@@ -3,6 +3,7 @@ import shutil
 import sys
 import tempfile
 import unittest
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -527,6 +528,47 @@ def test_finite_t_elastic_invalid_method_and_component_raise(tmp_path):
 def test_format_temperature_for_integer_and_fractional_values():
     assert _format_temperature(300.0) == "300"
     assert _format_temperature(300.5) == "300p5"
+
+
+class TestFiniteTelasticCoverage(unittest.TestCase):
+    def test_finite_t_elastic_generates_metadata_and_include_files(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            test_finite_t_elastic_generates_metadata_and_include_files(Path(tmp))
+
+    def test_finite_t_elastic_defaults_task_type_and_scalar_temperature(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            test_finite_t_elastic_defaults_task_type_and_scalar_temperature(Path(tmp))
+
+    def test_finite_t_elastic_deform_include_components(self):
+        cases = [
+            (1, "change_box all y scale ${scale_y} remap units box"),
+            (2, "change_box all z scale ${scale_z} remap units box"),
+            (3, "change_box all yz delta ${d_yz} remap units box"),
+            (4, "change_box all xz delta ${d_xz} remap units box"),
+            (5, "change_box all xy delta ${d_xy} remap units box"),
+        ]
+        for component, expected in cases:
+            with self.subTest(component=component):
+                test_finite_t_elastic_deform_include_components(component, expected)
+
+    def test_finite_t_elastic_helper_error_paths(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            test_finite_t_elastic_helper_error_paths(Path(tmp))
+
+    def test_finite_t_elastic_compute_lower_with_synthetic_stress_data(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            test_finite_t_elastic_compute_lower_with_synthetic_stress_data(Path(tmp))
+
+    def test_finite_t_elastic_missing_contcar_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            test_finite_t_elastic_missing_contcar_raises(Path(tmp))
+
+    def test_finite_t_elastic_invalid_method_and_component_raise(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            test_finite_t_elastic_invalid_method_and_component_raise(Path(tmp))
+
+    def test_format_temperature_for_integer_and_fractional_values(self):
+        test_format_temperature_for_integer_and_fractional_values()
 
 
 if __name__ == "__main__":

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -1,4 +1,7 @@
 import os
+import tempfile
+import unittest
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -418,3 +421,61 @@ def test_terminate_workflow_and_raise_if_failed():
 
     with pytest.raises(RuntimeError, match="Property workflow failed with 1 failed step"):
         generator._raise_if_failed(["detail"], "Property workflow")
+
+
+class TestFlowCoverage(unittest.TestCase):
+    def run_with_tmp_and_monkeypatch(self, func):
+        monkeypatch = pytest.MonkeyPatch()
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                return func(Path(tmp), monkeypatch)
+        finally:
+            monkeypatch.undo()
+
+    def run_with_monkeypatch(self, func):
+        monkeypatch = pytest.MonkeyPatch()
+        try:
+            return func(monkeypatch)
+        finally:
+            monkeypatch.undo()
+
+    def test_flow_static_helpers_and_failure_formatting(self):
+        test_flow_static_helpers_and_failure_formatting()
+
+    def test_download_artifact_with_retry_retries_transient_and_stops_on_missing(self):
+        self.run_with_monkeypatch(
+            test_download_artifact_with_retry_retries_transient_and_stops_on_missing
+        )
+
+    def test_step_artifact_lookup_and_main_log_download_from_child(self):
+        self.run_with_tmp_and_monkeypatch(
+            test_step_artifact_lookup_and_main_log_download_from_child
+        )
+
+    def test_diagnostic_artifact_downloads_only_allowed_debug_artifacts(self):
+        self.run_with_tmp_and_monkeypatch(
+            test_diagnostic_artifact_downloads_only_allowed_debug_artifacts
+        )
+
+    def test_set_relax_flows_and_tasks_expand_globs_and_skip_finished(self):
+        self.run_with_tmp_and_monkeypatch(
+            test_set_relax_flows_and_tasks_expand_globs_and_skip_finished
+        )
+
+    def test_set_props_flow_expands_properties_skips_and_removes_existing_dir(self):
+        self.run_with_tmp_and_monkeypatch(
+            test_set_props_flow_expands_properties_skips_and_removes_existing_dir
+        )
+
+    def test_set_props_tasks_uses_relax_output_or_pre_relaxed_base_and_errors(self):
+        self.run_with_tmp_and_monkeypatch(
+            test_set_props_tasks_uses_relax_output_or_pre_relaxed_base_and_errors
+        )
+
+    def test_submit_relax_props_and_joint_submit_only_paths(self):
+        self.run_with_tmp_and_monkeypatch(
+            test_submit_relax_props_and_joint_submit_only_paths
+        )
+
+    def test_terminate_workflow_and_raise_if_failed(self):
+        test_terminate_workflow_and_raise_if_failed()

--- a/tests/test_gamma_surface.py
+++ b/tests/test_gamma_surface.py
@@ -4,6 +4,7 @@ import shutil
 import sys
 import tempfile
 import unittest
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -316,6 +317,34 @@ def test_gamma_surface_compute_lower_with_synthetic_results(tmp_path):
     assert res_data["0.500000,1.000000"][0:2] == [1.0, 3.0]
     assert res_data["0.500000,1.000000"][2] == pytest.approx(8.01088285)
     assert (prop_dir / "result.json").is_file()
+
+
+class TestGammaSurfaceCoverage(unittest.TestCase):
+    def test_gamma_surface_reproduce_defaults_to_static_calculation(self):
+        test_gamma_surface_reproduce_defaults_to_static_calculation()
+
+    def test_gamma_surface_default_cal_setting_fills_missing_values(self):
+        test_gamma_surface_default_cal_setting_fills_missing_values()
+
+    def test_gamma_surface_resolve_equilibrium_structure_for_vasp_and_abacus(self):
+        monkeypatch = pytest.MonkeyPatch()
+        try:
+            test_gamma_surface_resolve_equilibrium_structure_for_vasp_and_abacus(
+                monkeypatch
+            )
+        finally:
+            monkeypatch.undo()
+
+    def test_gamma_surface_resolve_slip_length_numeric_vector_and_invalid(self):
+        test_gamma_surface_resolve_slip_length_numeric_vector_and_invalid()
+
+    def test_gamma_surface_post_process_injects_lammps_setforce(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            test_gamma_surface_post_process_injects_lammps_setforce(Path(tmp))
+
+    def test_gamma_surface_compute_lower_with_synthetic_results(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            test_gamma_surface_compute_lower_with_synthetic_results(Path(tmp))
 
 
 if __name__ == "__main__":

--- a/tests/test_gruneisen.py
+++ b/tests/test_gruneisen.py
@@ -52,6 +52,29 @@ def test_gruneisen_validation_rejects_low_cost_invalid_options(overrides, messag
         Gruneisen(valid_gruneisen_params(**overrides))
 
 
+class TestGruneisenValidationCoverage(unittest.TestCase):
+    def test_gruneisen_validation_rejects_low_cost_invalid_options(self):
+        cases = [
+            ({"temperatures": []}, "temperatures must contain"),
+            ({"alpha_mode": "bad"}, "alpha_mode"),
+            ({"bulk_modulus_source": "input"}, "bulk_modulus_source"),
+            ({"eos_model": "murnaghan"}, "eos_model"),
+            ({"approach": "bad"}, "approach"),
+            ({"cal_setting": {"relax_pos": False}}, "relax_pos"),
+            ({"cal_setting": {"relax_shape": True}}, "relax_shape"),
+            ({"cal_setting": {"relax_vol": True}}, "relax_vol"),
+            ({"volume_strains": [0.0, -0.02, 0.02]}, "strictly increasing"),
+            ({"volume_strains": [-0.02, 0.0, 0.0, 0.02]}, "duplicates"),
+            ({"temperatures": [50, 10]}, "temperatures must be strictly increasing"),
+            ({"volume_strains": [-0.02, 0.0, 0.03]}, "symmetric"),
+        ]
+        for overrides, message in cases:
+            with self.subTest(overrides=overrides):
+                test_gruneisen_validation_rejects_low_cost_invalid_options(
+                    overrides, message
+                )
+
+
 class TestGruneisen(unittest.TestCase):
     def setUp(self):
         tests_dir = Path(__file__).resolve().parent

--- a/tests/test_lammps_utils.py
+++ b/tests/test_lammps_utils.py
@@ -1,4 +1,7 @@
 import json
+import tempfile
+import unittest
+from pathlib import Path
 
 import pytest
 
@@ -468,3 +471,89 @@ def test_make_lammps_annealing_langevin_nve():
     assert "fix tg all langevin ${start_temp} ${target_temp} tdamp_var 24680" in script
     assert "fix tg all langevin ${target_temp} ${end_temp} tdamp_var 24680" in script
     assert script.count("unfix tg") == 3
+
+
+class TestLammpsUtils(unittest.TestCase):
+    def test_element_list_orders_by_lammps_type_id(self):
+        test_element_list_orders_by_lammps_type_id()
+
+    def test_make_lammps_eval_static_input_generation(self):
+        test_make_lammps_eval_static_input_generation()
+
+    def test_make_lammps_eval_mace_adds_atom_map_and_newton(self):
+        test_make_lammps_eval_mace_adds_atom_map_and_newton()
+
+    def test_standard_lammps_builders_mace_add_atom_map_and_newton(self):
+        builders = [
+            lambda: lammps_utils.make_lammps_equi(
+                "conf.lmp", TYPE_MAP, dummy_interaction, {"type": "mace"}
+            ),
+            lambda: lammps_utils.make_lammps_elastic(
+                "conf.lmp", TYPE_MAP, dummy_interaction, {"type": "mace"}
+            ),
+            lambda: lammps_utils.make_lammps_press_relax(
+                "conf.lmp", TYPE_MAP, 0.95, dummy_interaction, {"type": "mace"}
+            ),
+        ]
+        for builder in builders:
+            with self.subTest(builder=builder):
+                test_standard_lammps_builders_mace_add_atom_map_and_newton(builder)
+
+    def test_make_lammps_equi_relaxation_default_change_box(self):
+        test_make_lammps_equi_relaxation_default_change_box()
+
+    def test_make_lammps_equi_without_box_relax_for_fixed_cell_property(self):
+        test_make_lammps_equi_without_box_relax_for_fixed_cell_property()
+
+    def test_make_lammps_equi_new_deepmd_relaxation_uses_large_dump_step(self):
+        test_make_lammps_equi_new_deepmd_relaxation_uses_large_dump_step()
+
+    def test_make_lammps_equi_new_deepmd_property_detour_skips_middle_minimizations(self):
+        test_make_lammps_equi_new_deepmd_property_detour_skips_middle_minimizations()
+
+    def test_make_lammps_elastic_input_generation(self):
+        test_make_lammps_elastic_input_generation()
+
+    def test_make_lammps_press_relax_eos_input_generation(self):
+        test_make_lammps_press_relax_eos_input_generation()
+
+    def test_make_lammps_finite_t_latt_default_cal_setting(self):
+        test_make_lammps_finite_t_latt_default_cal_setting()
+
+    def test_make_lammps_finite_t_latt_adiabatic_ensemble(self):
+        test_make_lammps_finite_t_latt_adiabatic_ensemble()
+
+    def test_make_lammps_finite_t_latt_langevin_thermostat(self):
+        test_make_lammps_finite_t_latt_langevin_thermostat()
+
+    def test_make_lammps_finite_t_latt_custom_settings(self):
+        test_make_lammps_finite_t_latt_custom_settings()
+
+    def test_make_lammps_finite_t_elastic_equi_role(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            test_make_lammps_finite_t_elastic_equi_role(Path(tmp))
+
+    def test_make_lammps_finite_t_elastic_mace_setup(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            test_make_lammps_finite_t_elastic_mace_setup(Path(tmp))
+
+    def test_make_lammps_finite_t_elastic_response_roles(self):
+        for role in ["reference", "strained"]:
+            with self.subTest(role=role), tempfile.TemporaryDirectory() as tmp:
+                test_make_lammps_finite_t_elastic_response_roles(Path(tmp), role)
+
+    def test_make_lammps_finite_t_elastic_invalid_role_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            test_make_lammps_finite_t_elastic_invalid_role_raises(Path(tmp))
+
+    def test_make_lammps_annealing_default_nose_hoover_npt(self):
+        test_make_lammps_annealing_default_nose_hoover_npt()
+
+    def test_make_lammps_annealing_nose_hoover_nvt(self):
+        test_make_lammps_annealing_nose_hoover_nvt()
+
+    def test_make_lammps_annealing_langevin_nph(self):
+        test_make_lammps_annealing_langevin_nph()
+
+    def test_make_lammps_annealing_langevin_nve(self):
+        test_make_lammps_annealing_langevin_nve()

--- a/tests/test_mfp_eosfit.py
+++ b/tests/test_mfp_eosfit.py
@@ -1,3 +1,7 @@
+import tempfile
+import unittest
+from pathlib import Path
+
 import numpy as np
 import pytest
 
@@ -195,3 +199,83 @@ def test_fit_birch_murnaghan_invalid_inputs_raise():
 
     with pytest.raises(ValueError, match="at least 3"):
         mfp_eosfit.init_guess_from_data([1, 2], [1, 2])
+
+
+class TestMfpEosfitCoverage(unittest.TestCase):
+    def test_eos_lists_include_expected_models(self):
+        test_eos_lists_include_expected_models()
+
+    def test_four_parameter_eos_models_equal_e0_at_v0(self):
+        for model in [
+            mfp_eosfit.murnaghan,
+            mfp_eosfit.birch,
+            mfp_eosfit.BM4,
+            mfp_eosfit.rBM4,
+            mfp_eosfit.LOG4,
+            mfp_eosfit.rPT4,
+            mfp_eosfit.vinet,
+            mfp_eosfit.universal,
+        ]:
+            with self.subTest(model=model.__name__):
+                test_four_parameter_eos_models_equal_e0_at_v0(model)
+
+    def test_birch_residual_is_zero_for_matching_data(self):
+        test_birch_residual_is_zero_for_matching_data()
+
+    def test_four_parameter_residual_wrappers_zero_for_matching_data(self):
+        for model, residual in [
+            (mfp_eosfit.murnaghan, mfp_eosfit.res_murnaghan),
+            (mfp_eosfit.mBM4, mfp_eosfit.res_mBM4),
+            (mfp_eosfit.BM4, mfp_eosfit.res_BM4),
+            (mfp_eosfit.rBM4, mfp_eosfit.res_rBM4),
+            (mfp_eosfit.universal, mfp_eosfit.res_universal),
+            (mfp_eosfit.LOG4, mfp_eosfit.res_LOG4),
+            (mfp_eosfit.rPT4, mfp_eosfit.res_rPT4),
+            (mfp_eosfit.vinet, mfp_eosfit.res_vinet),
+            (mfp_eosfit.Li4p, mfp_eosfit.res_Li4p),
+        ]:
+            with self.subTest(model=model.__name__):
+                test_four_parameter_residual_wrappers_zero_for_matching_data(
+                    model, residual
+                )
+
+    def test_five_parameter_eos_models_equal_e0_at_v0(self):
+        for model in [
+            mfp_eosfit.mBM5,
+            mfp_eosfit.BM5,
+            mfp_eosfit.rBM5,
+            mfp_eosfit.LOG5,
+            mfp_eosfit.rPT5,
+        ]:
+            with self.subTest(model=model.__name__):
+                test_five_parameter_eos_models_equal_e0_at_v0(model)
+
+    def test_eos_property_calculators_return_expected_shapes(self):
+        test_eos_property_calculators_return_expected_shapes()
+
+    def test_other_eos_residual_wrappers_zero_for_matching_data(self):
+        for model, residual, pars in [
+            (mfp_eosfit.morse, mfp_eosfit.res_morse, [-3.0, 0.5, 4.0, 10.0]),
+            (mfp_eosfit.morse_AB, mfp_eosfit.res_morse_AB, [-3.0, 0.5, 1.0, 10.0]),
+            (mfp_eosfit.morse_3p, mfp_eosfit.res_morse_3p, [-3.0, 0.5, 10.0]),
+            (mfp_eosfit.mie, mfp_eosfit.res_mie, [-3.0, 0.5, 4.0, 10.0]),
+            (mfp_eosfit.mie_simple, mfp_eosfit.res_mie_simple, [-3.0, 0.5, 10.0, 2.0]),
+        ]:
+            with self.subTest(model=model.__name__):
+                test_other_eos_residual_wrappers_zero_for_matching_data(
+                    model, residual, pars
+                )
+
+    def test_read_ve_and_init_guess_from_data(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            test_read_ve_and_init_guess_from_data(Path(tmp))
+
+    def test_read_velp_and_vlp_parse_selected_ranges(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            test_read_velp_and_vlp_parse_selected_ranges(Path(tmp))
+
+    def test_fit_birch_murnaghan_free_and_fixed_bp_with_synthetic_data(self):
+        test_fit_birch_murnaghan_free_and_fixed_bp_with_synthetic_data()
+
+    def test_fit_birch_murnaghan_invalid_inputs_raise(self):
+        test_fit_birch_murnaghan_invalid_inputs_raise()


### PR DESCRIPTION
Refactors the test suite to improve coverage reporting and maintainability by wrapping existing test functions in `unittest.TestCase` subclasses. 